### PR TITLE
Add new translucent allies system

### DIFF
--- a/src/ZombieHorde2/acs_source/zh2game/cvars.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/cvars.acs
@@ -44,7 +44,7 @@ strict namespace ZH2Game
     internal bool GetAutoUseConsumableItems(int playerId) { return (bool)GetUserCvar(playerId, "cl_zh2_autouseconsumableitems"); }
 
     internal bool GetSvTranslucentAllies() { return (bool)GetCvar("sv_zh2_translucentallies"); }
-    internal TranslucentAlliesT GetTranslucentAllies()
+    internal TranslucentAlliesT GetClTranslucentAllies()
     {
         // Note: defaults to "on with required cvars" when the value is out of bounds.
         switch(BCSUTILS::Clamp(GetCvar("cl_zh2_translucentallies"), 0, 2))

--- a/src/ZombieHorde2/acs_source/zh2game/cvars.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/cvars.acs
@@ -42,6 +42,7 @@ strict namespace ZH2Game
     internal int GetShownInventoryItems() { return BCSUTILS::Clamp(GetCvar("cl_zh2_showninventoryitems"), 1, 11); }
     internal bool GetWrapInventoryItems() { return (bool)GetCvar("cl_zh2_wrapinventoryitems"); }
     internal bool GetAutoUseConsumableItems(int playerId) { return (bool)GetUserCvar(playerId, "cl_zh2_autouseconsumableitems"); }
+    internal bool GetTranslucentAllies() { return (bool)GetCvar("cl_zh2_translucentallies"); }
 
     // Player - Music
     internal bool GetIgnoreRadioMusic() { return (bool)GetCvar("cl_zh2_ignoreradiomusic"); }

--- a/src/ZombieHorde2/acs_source/zh2game/cvars.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/cvars.acs
@@ -55,6 +55,7 @@ strict namespace ZH2Game
                 return TRANSLUCENT_ALLIES_ON_WITH_REQUIRED_CVARS;
         }
     }
+    internal int GetBaseAllyTranslucency() { return BCSUTILS::Clamp(GetCvar("cl_zh2_baseallytranslucency"), 1, 100); }
 
     // Player - Music
     internal bool GetIgnoreRadioMusic() { return (bool)GetCvar("cl_zh2_ignoreradiomusic"); }

--- a/src/ZombieHorde2/acs_source/zh2game/cvars.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/cvars.acs
@@ -58,7 +58,7 @@ strict namespace ZH2Game
                 return TRANSLUCENT_ALLIES_ON_WITH_REQUIRED_CVARS;
         }
     }
-    internal int GetBaseAllyTranslucency() { return BCSUTILS::Clamp(GetCvar("cl_zh2_baseallytranslucency"), 1, 100); }
+    internal int GetBaseAllyTranslucency() { return BCSUTILS::Clamp(GetCvar("cl_zh2_baseallytranslucency"), 30, 100); }
 
     // Player - Music
     internal bool GetIgnoreRadioMusic() { return (bool)GetCvar("cl_zh2_ignoreradiomusic"); }

--- a/src/ZombieHorde2/acs_source/zh2game/cvars.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/cvars.acs
@@ -42,7 +42,19 @@ strict namespace ZH2Game
     internal int GetShownInventoryItems() { return BCSUTILS::Clamp(GetCvar("cl_zh2_showninventoryitems"), 1, 11); }
     internal bool GetWrapInventoryItems() { return (bool)GetCvar("cl_zh2_wrapinventoryitems"); }
     internal bool GetAutoUseConsumableItems(int playerId) { return (bool)GetUserCvar(playerId, "cl_zh2_autouseconsumableitems"); }
-    internal bool GetTranslucentAllies() { return (bool)GetCvar("cl_zh2_translucentallies"); }
+    internal TranslucentAlliesT GetTranslucentAllies()
+    {
+        // Note: defaults to "on with required cvars" when the value is out of bounds.
+        switch(BCSUTILS::Clamp(GetCvar("cl_zh2_translucentallies"), 0, 2))
+        {
+            case 0:
+                return TRANSLUCENT_ALLIES_OFF;
+            case 2:
+                return TRANSLUCENT_ALLIES_ON;
+            default:
+                return TRANSLUCENT_ALLIES_ON_WITH_REQUIRED_CVARS;
+        }
+    }
 
     // Player - Music
     internal bool GetIgnoreRadioMusic() { return (bool)GetCvar("cl_zh2_ignoreradiomusic"); }
@@ -139,6 +151,8 @@ strict namespace ZH2Game
     // Zandronum specific
     internal bool GetNoRespawnInvul() { return (bool)GetCvar("sv_norespawninvul"); }
     internal bool GetSvCheats() { return (bool)GetCvar("sv_cheats"); }
+    internal bool GetShootThroughAllies() { return (bool)GetCvar("sv_shootthroughallies"); }
+    internal bool GetUnblockAllies() { return (bool)GetCvar("sv_unblockallies"); }
     internal bool GetProtectCVars() { return (bool)GetCvar("cl_protectcvars"); }
     internal int GetMaxPlayers() { return BCSUTILS::Clamp(GetCvar("sv_maxplayers"), 1, 64); }
 }

--- a/src/ZombieHorde2/acs_source/zh2game/cvars.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/cvars.acs
@@ -42,6 +42,8 @@ strict namespace ZH2Game
     internal int GetShownInventoryItems() { return BCSUTILS::Clamp(GetCvar("cl_zh2_showninventoryitems"), 1, 11); }
     internal bool GetWrapInventoryItems() { return (bool)GetCvar("cl_zh2_wrapinventoryitems"); }
     internal bool GetAutoUseConsumableItems(int playerId) { return (bool)GetUserCvar(playerId, "cl_zh2_autouseconsumableitems"); }
+
+    internal bool GetSvTranslucentAllies() { return (bool)GetCvar("sv_zh2_translucentallies"); }
     internal TranslucentAlliesT GetTranslucentAllies()
     {
         // Note: defaults to "on with required cvars" when the value is out of bounds.

--- a/src/ZombieHorde2/acs_source/zh2game/cvars.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/cvars.acs
@@ -44,6 +44,7 @@ strict namespace ZH2Game
     internal bool GetAutoUseConsumableItems(int playerId) { return (bool)GetUserCvar(playerId, "cl_zh2_autouseconsumableitems"); }
 
     internal bool GetSvTranslucentAllies() { return (bool)GetCvar("sv_zh2_translucentallies"); }
+    internal int GetTranslucentAlliesDistance() { return BCSUTILS::Clamp(GetCvar("cl_zh2_translucentalliesdistance"), 100, 1000); }
     internal TranslucentAlliesT GetClTranslucentAllies()
     {
         // Note: defaults to "on with required cvars" when the value is out of bounds.

--- a/src/ZombieHorde2/acs_source/zh2game/gameloop/playerloop.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/gameloop/playerloop.acs
@@ -49,6 +49,7 @@ strict namespace GameLoop
             RoundTimer::TicClient();
             Game::FullServerTicClient();
             Player::HeartbeatTicClient();
+            Player::TranslucentAlliesTicClient();
             Game::ClientDeathCamTic();
 
             for (int i = 0; i < BCSUtils::MAX_PLAYERS; ++i)

--- a/src/ZombieHorde2/acs_source/zh2game/main.h.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/main.h.acs
@@ -174,6 +174,10 @@ strict namespace ZH2Game
         int SurvivorsShuffledCount;
         int HordeShuffledCount;
         int DeadShuffledCount;
+
+        // Clientside, this boolean tracks if we are working with translucent allies.
+        // Required in order to properly unset the state back to opague allies when disabled.
+        bool TranslucentAlliesEnabled;
     };
 
     // General game info. Persisting between rounds.

--- a/src/ZombieHorde2/acs_source/zh2game/main.h.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/main.h.acs
@@ -29,6 +29,13 @@ strict namespace ZH2Game
 {
     #define PERSISTINGGAMECONTEXTINDEX 1
     
+    internal enum TranslucentAlliesT : int
+    {
+        TRANSLUCENT_ALLIES_OFF,
+        TRANSLUCENT_ALLIES_ON_WITH_REQUIRED_CVARS,
+        TRANSLUCENT_ALLIES_ON,
+    };
+    
     internal enum ZombieSkinBehaviourT : int
     {
         BEHAVIOUR_DEFAULT,

--- a/src/ZombieHorde2/acs_source/zh2game/player/player.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/player.acs
@@ -16,6 +16,7 @@
 #include "sprint.acs"
 #include "panic.acs"
 #include "taunt.acs"
+#include "translucentallies.acs"
 #include "initialzombie.acs"
 #include "heartbeat.acs"
 

--- a/src/ZombieHorde2/acs_source/zh2game/player/translucentallies.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/translucentallies.acs
@@ -1,0 +1,100 @@
+#ifdef __IMPORTED__
+    #error This file must be #included.
+#endif
+
+strict namespace Player
+{
+	#define TRANSLUCENT_ALLIES_DISTANCE_MAX 256.0
+
+    internal void TranslucentAlliesTicClient()
+    {
+        bool translucentAlliesEnabled = ZH2Game::GetTranslucentAllies();
+
+        // Do we need to toggle translucency?
+        if (GetTranslucentAlliesEnabled() != translucentAlliesEnabled)
+        {
+            SetTranslucentAlliesEnabled(translucentAlliesEnabled);
+
+            if (!translucentAlliesEnabled)
+                DisableTranslucentAlliesProperties(translucentAlliesEnabled);
+        }
+
+        if (translucentAlliesEnabled)
+            UpdateTranslucentAlliesAlpha();
+    }
+
+    internal void SetTranslucentAlliesEnabled(bool enabled)
+    {
+        ZH2Game::GameContext.TranslucentAlliesEnabled = enabled;
+    }
+    
+    internal bool GetTranslucentAlliesEnabled()
+    {
+        return ZH2Game::GameContext.TranslucentAlliesEnabled;
+    }
+
+    // Handles setting actors back to being opaque.
+    internal void DisableTranslucentAlliesProperties(bool enabled)
+    {
+        int style = enabled ? STYLE_TRANSLUCENT : STYLE_NORMAL;
+        for (int i = 0; i < BCSUtils::MAX_PLAYERS; ++i)
+        {
+            if (!PlayerInGame(i))
+                continue;
+
+            int tid = Identity::GetTID(i);
+            if (!BCSUTILS::ActorIsAlive(tid))
+                continue;
+
+            SetActorProperty(tid, APROP_ALPHA, 1.0);
+			SetActorProperty(tid, APROP_RENDERSTYLE, STYLE_NORMAL);
+        }
+    }
+
+    // Handles actually setting the alpha values on all actors.
+    internal void UpdateTranslucentAlliesAlpha()
+    {
+        Player::SpecieTypeT specie = Player::GetSpecie();
+
+        for (int i = 0; i < BCSUtils::MAX_PLAYERS; ++i)
+        {
+            // Ignore self.
+            if (ConsolePlayerNumber() == i)
+                continue;
+
+            if (!PlayerInGame(i))
+                continue;
+
+            int tid = Identity::GetTID(i);
+            if (!BCSUTILS::ActorIsAlive(tid))
+                continue;
+            
+            // Helper function to call if the player didn't match.
+            void RemoveTranslucent()
+            {
+                SetActorProperty(tid, APROP_ALPHA, 1.0);
+                SetActorProperty(tid, APROP_RENDERSTYLE, STYLE_NORMAL);
+            }
+                
+            // Translucency only works on the same specie.
+            // Infection/curing also adjusts properly this way.
+            if (Player::GetPlayerSpecie(i) != specie)
+            {
+                RemoveTranslucent();
+                continue;
+            }
+
+            // Distance check which also increases/decreases alpha based on distance.
+            fixed distance = BCSUtils::ActorDistance(ActivatorTID(), tid);
+			if (distance > TRANSLUCENT_ALLIES_DISTANCE_MAX)
+            {
+                RemoveTranslucent();
+                continue;
+            }
+
+			fixed alpha = BCSUtils::Min(1.0, distance / TRANSLUCENT_ALLIES_DISTANCE_MAX);
+			SetActorProperty(tid, APROP_ALPHA, alpha);
+			SetActorProperty(tid, APROP_RENDERSTYLE, STYLE_TRANSLUCENT);
+        }
+    }
+}

--- a/src/ZombieHorde2/acs_source/zh2game/player/translucentallies.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/translucentallies.acs
@@ -61,6 +61,9 @@ strict namespace Player
     {
         Player::SpecieTypeT specie = Player::GetSpecie();
 
+        // Base configured translucency value on players.
+        fixed baseAlpha = fixed(ZH2Game::GetBaseAllyTranslucency()) / 100.0;
+
         for (int i = 0; i < BCSUtils::MAX_PLAYERS; ++i)
         {
             // Ignore self.
@@ -74,32 +77,20 @@ strict namespace Player
             if (!BCSUTILS::ActorIsAlive(tid))
                 continue;
             
-            // Helper function to call if the player didn't match.
-            void RemoveTranslucent()
-            {
-                SetActorProperty(tid, APROP_ALPHA, 1.0);
-                SetActorProperty(tid, APROP_RENDERSTYLE, STYLE_NORMAL);
-            }
-                
             // Translucency only works on the same specie.
             // Infection/curing also adjusts properly this way.
             if (Player::GetPlayerSpecie(i) != specie)
             {
-                RemoveTranslucent();
+                SetActorProperty(tid, APROP_ALPHA, 1.0);
+                SetActorProperty(tid, APROP_RENDERSTYLE, STYLE_NORMAL);
                 continue;
             }
 
             // Distance check which also increases/decreases alpha based on distance.
             fixed distance = BCSUtils::ActorDistance(ActivatorTID(), tid);
-			if (distance > TRANSLUCENT_ALLIES_DISTANCE_MAX)
-            {
-                RemoveTranslucent();
-                continue;
-            }
-
-			fixed alpha = BCSUtils::Min(1.0, distance / TRANSLUCENT_ALLIES_DISTANCE_MAX);
+			fixed alpha = baseAlpha * (fixed)BCSUtils::Min(1.0, distance / TRANSLUCENT_ALLIES_DISTANCE_MAX);
 			SetActorProperty(tid, APROP_ALPHA, alpha);
-			SetActorProperty(tid, APROP_RENDERSTYLE, STYLE_TRANSLUCENT);
+			SetActorProperty(tid, APROP_RENDERSTYLE, alpha != 1.0 ? STYLE_TRANSLUCENT : STYLE_NORMAL);
         }
     }
 }

--- a/src/ZombieHorde2/acs_source/zh2game/player/translucentallies.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/translucentallies.acs
@@ -10,10 +10,12 @@ strict namespace Player
     {
         // Translucent allies might need some additional cvars enabled.
         // If we have the setting set for them, one of these cvars must be enabled.
+        bool translucentAlliesEnabledServer = ZH2Game::GetSvTranslucentAllies();
         ZH2Game::TranslucentAlliesT translucentAlliesEnabledCVar = ZH2Game::GetTranslucentAllies();
-        bool translucentAlliesEnabled = translucentAlliesEnabledCVar == ZH2Game::TRANSLUCENT_ALLIES_ON
-            || translucentAlliesEnabledCVar == ZH2Game::TRANSLUCENT_ALLIES_ON_WITH_REQUIRED_CVARS
-                && (ZH2Game::GetShootThroughAllies() || ZH2Game::GetUnblockAllies());
+        bool translucentAlliesEnabled = translucentAlliesEnabledServer
+            && (translucentAlliesEnabledCVar == ZH2Game::TRANSLUCENT_ALLIES_ON
+                || translucentAlliesEnabledCVar == ZH2Game::TRANSLUCENT_ALLIES_ON_WITH_REQUIRED_CVARS
+                    && (ZH2Game::GetShootThroughAllies() || ZH2Game::GetUnblockAllies()));
 
         // Do we need to toggle translucency?
         if (GetTranslucentAlliesEnabled() != translucentAlliesEnabled)

--- a/src/ZombieHorde2/acs_source/zh2game/player/translucentallies.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/translucentallies.acs
@@ -11,10 +11,10 @@ strict namespace Player
         // Translucent allies might need some additional cvars enabled.
         // If we have the setting set for them, one of these cvars must be enabled.
         bool translucentAlliesEnabledServer = ZH2Game::GetSvTranslucentAllies();
-        ZH2Game::TranslucentAlliesT translucentAlliesEnabledCVar = ZH2Game::GetTranslucentAllies();
+        ZH2Game::TranslucentAlliesT translucentAlliesEnabledClient = ZH2Game::GetClTranslucentAllies();
         bool translucentAlliesEnabled = translucentAlliesEnabledServer
-            && (translucentAlliesEnabledCVar == ZH2Game::TRANSLUCENT_ALLIES_ON
-                || translucentAlliesEnabledCVar == ZH2Game::TRANSLUCENT_ALLIES_ON_WITH_REQUIRED_CVARS
+            && (translucentAlliesEnabledClient == ZH2Game::TRANSLUCENT_ALLIES_ON
+                || translucentAlliesEnabledClient == ZH2Game::TRANSLUCENT_ALLIES_ON_WITH_REQUIRED_CVARS
                     && (ZH2Game::GetShootThroughAllies() || ZH2Game::GetUnblockAllies()));
 
         // Do we need to toggle translucency?

--- a/src/ZombieHorde2/acs_source/zh2game/player/translucentallies.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/translucentallies.acs
@@ -8,7 +8,12 @@ strict namespace Player
 
     internal void TranslucentAlliesTicClient()
     {
-        bool translucentAlliesEnabled = ZH2Game::GetTranslucentAllies();
+        // Translucent allies might need some additional cvars enabled.
+        // If we have the setting set for them, one of these cvars must be enabled.
+        ZH2Game::TranslucentAlliesT translucentAlliesEnabledCVar = ZH2Game::GetTranslucentAllies();
+        bool translucentAlliesEnabled = translucentAlliesEnabledCVar == ZH2Game::TRANSLUCENT_ALLIES_ON
+            || translucentAlliesEnabledCVar == ZH2Game::TRANSLUCENT_ALLIES_ON_WITH_REQUIRED_CVARS
+                && (ZH2Game::GetShootThroughAllies() || ZH2Game::GetUnblockAllies());
 
         // Do we need to toggle translucency?
         if (GetTranslucentAlliesEnabled() != translucentAlliesEnabled)

--- a/src/ZombieHorde2/acs_source/zh2game/player/translucentallies.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/translucentallies.acs
@@ -4,8 +4,6 @@
 
 strict namespace Player
 {
-	#define TRANSLUCENT_ALLIES_DISTANCE_MAX 256.0
-
     internal void TranslucentAlliesTicClient()
     {
         // Translucent allies might need some additional cvars enabled.
@@ -62,6 +60,7 @@ strict namespace Player
     internal void UpdateTranslucentAlliesAlpha()
     {
         Player::SpecieTypeT specie = Player::GetSpecie();
+        fixed translucentAlliesDistance = fixed(ZH2Game::GetTranslucentAlliesDistance());
 
         // Base configured translucency value on players.
         fixed baseAlpha = fixed(ZH2Game::GetBaseAllyTranslucency()) / 100.0;
@@ -90,7 +89,7 @@ strict namespace Player
 
             // Distance check which also increases/decreases alpha based on distance.
             fixed distance = BCSUtils::ActorDistance(ActivatorTID(), tid);
-			fixed alpha = baseAlpha * (fixed)BCSUtils::Min(1.0, distance / TRANSLUCENT_ALLIES_DISTANCE_MAX);
+			fixed alpha = baseAlpha * (fixed)BCSUtils::Min(1.0, distance / translucentAlliesDistance);
 			SetActorProperty(tid, APROP_ALPHA, alpha);
 			SetActorProperty(tid, APROP_RENDERSTYLE, alpha != 1.0 ? STYLE_TRANSLUCENT : STYLE_NORMAL);
         }

--- a/src/ZombieHorde2/cvarinfo.txt
+++ b/src/ZombieHorde2/cvarinfo.txt
@@ -25,6 +25,8 @@ server bool sv_zh2_usedeadspectators = true;
 user int cl_zh2_showninventoryitems = 5;
 user bool cl_zh2_wrapinventoryitems = false;
 user bool cl_zh2_autouseconsumableitems = true;
+
+server bool sv_zh2_translucentallies = true;
 user int cl_zh2_translucentallies = 1;
 user int cl_zh2_baseallytranslucency = 80;
 

--- a/src/ZombieHorde2/cvarinfo.txt
+++ b/src/ZombieHorde2/cvarinfo.txt
@@ -25,7 +25,7 @@ server bool sv_zh2_usedeadspectators = true;
 user int cl_zh2_showninventoryitems = 5;
 user bool cl_zh2_wrapinventoryitems = false;
 user bool cl_zh2_autouseconsumableitems = true;
-user bool cl_zh2_translucentallies = true;
+user int cl_zh2_translucentallies = 1;
 
 // Player - Music
 user bool cl_zh2_ignoreradiomusic = false;

--- a/src/ZombieHorde2/cvarinfo.txt
+++ b/src/ZombieHorde2/cvarinfo.txt
@@ -26,6 +26,7 @@ user int cl_zh2_showninventoryitems = 5;
 user bool cl_zh2_wrapinventoryitems = false;
 user bool cl_zh2_autouseconsumableitems = true;
 user int cl_zh2_translucentallies = 1;
+user int cl_zh2_baseallytranslucency = 80;
 
 // Player - Music
 user bool cl_zh2_ignoreradiomusic = false;

--- a/src/ZombieHorde2/cvarinfo.txt
+++ b/src/ZombieHorde2/cvarinfo.txt
@@ -28,6 +28,7 @@ user bool cl_zh2_autouseconsumableitems = true;
 
 server bool sv_zh2_translucentallies = true;
 user int cl_zh2_translucentallies = 1;
+user int cl_zh2_translucentalliesdistance = 256;
 user int cl_zh2_baseallytranslucency = 80;
 
 // Player - Music

--- a/src/ZombieHorde2/cvarinfo.txt
+++ b/src/ZombieHorde2/cvarinfo.txt
@@ -25,6 +25,7 @@ server bool sv_zh2_usedeadspectators = true;
 user int cl_zh2_showninventoryitems = 5;
 user bool cl_zh2_wrapinventoryitems = false;
 user bool cl_zh2_autouseconsumableitems = true;
+user bool cl_zh2_translucentallies = true;
 
 // Player - Music
 user bool cl_zh2_ignoreradiomusic = false;

--- a/src/ZombieHorde2/menudef.player
+++ b/src/ZombieHorde2/menudef.player
@@ -7,7 +7,11 @@ OptionMenu "ZH2PlayerMenu"
 	Slider "Shown items", "cl_zh2_showninventoryitems", 1.0, 11.0, 1.0
 	Option "Wrap items", "cl_zh2_wrapinventoryitems", "YesNo"
 	Option "Auto use consumable items (kevlar, energy, medikit)", "cl_zh2_autouseconsumableitems", "YesNo"
+	
+	StaticText " "
+	
 	Option "Enable translucent allies", "cl_zh2_translucentallies", "TranslucentType"
+	Slider "Minimum ally translucency", "cl_zh2_baseallytranslucency", 1, 100, 1
 	
 	StaticText " "
 	

--- a/src/ZombieHorde2/menudef.player
+++ b/src/ZombieHorde2/menudef.player
@@ -13,7 +13,7 @@ OptionMenu "ZH2PlayerMenu"
 	Option "Enable translucent allies (server)", "sv_zh2_translucentallies", "YesNo"
 	Slider "Translucent allies fade distance", "cl_zh2_translucentalliesdistance", 100, 1000, 1
 	Option "Enable translucent allies", "cl_zh2_translucentallies", "TranslucentType"
-	Slider "Minimum ally translucency", "cl_zh2_baseallytranslucency", 1, 100, 1
+	Slider "Minimum ally translucency", "cl_zh2_baseallytranslucency", 30, 100, 1
 	
 	StaticText " "
 	

--- a/src/ZombieHorde2/menudef.player
+++ b/src/ZombieHorde2/menudef.player
@@ -11,6 +11,7 @@ OptionMenu "ZH2PlayerMenu"
 	StaticText " "
 	
 	Option "Enable translucent allies (server)", "sv_zh2_translucentallies", "YesNo"
+	Slider "Translucent allies fade distance", "cl_zh2_translucentalliesdistance", 100, 1000, 1
 	Option "Enable translucent allies", "cl_zh2_translucentallies", "TranslucentType"
 	Slider "Minimum ally translucency", "cl_zh2_baseallytranslucency", 1, 100, 1
 	

--- a/src/ZombieHorde2/menudef.player
+++ b/src/ZombieHorde2/menudef.player
@@ -10,6 +10,7 @@ OptionMenu "ZH2PlayerMenu"
 	
 	StaticText " "
 	
+	Option "Enable translucent allies (server)", "sv_zh2_translucentallies", "YesNo"
 	Option "Enable translucent allies", "cl_zh2_translucentallies", "TranslucentType"
 	Slider "Minimum ally translucency", "cl_zh2_baseallytranslucency", 1, 100, 1
 	

--- a/src/ZombieHorde2/menudef.player
+++ b/src/ZombieHorde2/menudef.player
@@ -7,7 +7,7 @@ OptionMenu "ZH2PlayerMenu"
 	Slider "Shown items", "cl_zh2_showninventoryitems", 1.0, 11.0, 1.0
 	Option "Wrap items", "cl_zh2_wrapinventoryitems", "YesNo"
 	Option "Auto use consumable items (kevlar, energy, medikit)", "cl_zh2_autouseconsumableitems", "YesNo"
-	Option "Enable translucent allies", "cl_zh2_translucentallies", "YesNo"
+	Option "Enable translucent allies", "cl_zh2_translucentallies", "TranslucentType"
 	
 	StaticText " "
 	

--- a/src/ZombieHorde2/menudef.player
+++ b/src/ZombieHorde2/menudef.player
@@ -7,6 +7,7 @@ OptionMenu "ZH2PlayerMenu"
 	Slider "Shown items", "cl_zh2_showninventoryitems", 1.0, 11.0, 1.0
 	Option "Wrap items", "cl_zh2_wrapinventoryitems", "YesNo"
 	Option "Auto use consumable items (kevlar, energy, medikit)", "cl_zh2_autouseconsumableitems", "YesNo"
+	Option "Enable translucent allies", "cl_zh2_translucentallies", "YesNo"
 	
 	StaticText " "
 	

--- a/src/ZombieHorde2/menudef.txt
+++ b/src/ZombieHorde2/menudef.txt
@@ -17,6 +17,13 @@ OptionValue "FlareType"
 	8, "Yellow"
 }
 
+OptionValue "TranslucentType"
+{
+	0, "Off"
+	1, "On if required cvars enabled"
+	2, "On"
+}
+
 OptionValue "ZombieSkinBehaviour"
 {
 	0, "Default"


### PR DESCRIPTION
The system allows for controlling translucency between allies, and can be configured to increase or decrease translucency based on distance and also by setting a base translucency.
The system only works for the same specie.
New cvars:
- **sv_zh2_translucentallies** - Cvar manages translucent clients as a whole regardless of client settings.
- **cl_zh2_translucentalliesdistance** - Manages the distance at which allies start to turn translucent.
- **cl_zh2_translucentallies** - Manages whether allies should be translucent in general.
    - 0 - off
    - 1 - on when either cvar `sv_shootthroughallies` or `sv_unblockallies` is enabled. This option improves support, ensuring translucent allies have more of a reason to be enabled (since it otherwise doesn’t work as well when everything is blocking anyway).
    - 2 - on
- **cl_zh2_baseallytranslucency** - Sets the base translucency that clients must always have. This value is then gradually decremented based on distance.
