### PR TITLE
Fix reward for powers

### DIFF
--- a/src/ZombieHorde2/acs_source/zh2game/reward/givereward.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/reward/givereward.acs
@@ -72,7 +72,7 @@ strict namespace Reward
 
 		if ((raw)callGive != 0 && callGive != "")
 		{
-            if (!ACS_NamedExecuteAlways(callGive, 0))
+            if (!ACS_NamedExecuteAlways(callGive, 0,id))
                 Logger::logError(LogSource, "Failed to call script \"" + callGive + "\" for reward index " + str(index) + ".");
         }
 


### PR DESCRIPTION
The ACS was executed without passing the player ID to the script, causing it to default to 0. This means only player 0 would receive the power (and also receive powers from other players rewards).