### PR TITLE
Fix visual increment timer

### DIFF
--- a/src/ZombieHorde2/acs_source/zh2game/game/roundtime.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/game/roundtime.acs
@@ -42,6 +42,7 @@ strict namespace Game
 
     script "zh2_internal_game_visualaddtime"(int ticDiff) clientside
     {
+        SetActivatorToPlayer(ConsolePlayerNumber());
         if (!ZH2Game::GetDrawRoundHud())
             terminate;
 


### PR DESCRIPTION
Visual Increment Timer wasn't being displayed when infecting other players online.