### PR TITLE
Sync `dev` to `dev-more_hud_improvements`

### DIFF
--- a/src/ZombieHorde2/acs_source/zh2game/round/round.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/round/round.acs
@@ -56,34 +56,30 @@ strict namespace Round
 
     internal int GetIndexOfKnownRoundStateType(KnownRoundStateT stateType) { return (int)stateType; }
 
-    internal KnownRoundStateT GetKnownRoundStateTypeByIndex(int stateIndex)
+    // Returns STATENONE if the round timer is not known.
+    internal KnownRoundStateT GetKnownRoundStateTypeByIndex(int index)
     {
-        static KnownRoundStateT collection[] = { StateNone, StatePregame, StateStarting, StateCountdown, StatePlaying, StateEnding, STATEVOTING };
-        
-        // No known round state.
-        if (stateIndex < StatePregame && stateIndex > STATEVOTING)
-            return StateNone;
-        
-        return collection[stateIndex];
+        static KnownRoundStateT collection[] = { STATEPREGAME, STATESTARTING, STATECOUNTDOWN, STATEPLAYING, STATEENDING, STATEVOTING };
+        foreach(KnownRoundStateT item; collection)
+        {
+            if (index != item)
+                continue;
+            
+            return item;
+        }
+
+        return STATENONE;
     }
 
-    internal str GetRoundStateIndexAsString(int stateIndex)
+    internal str GetRoundStateIndexAsString(int index)
     {
-        // No known round state, return custom and the index.
-        if (stateIndex < StatePregame || stateIndex > STATEVOTING)
-            return "Custom (" + str(stateIndex) + ")";
-
-        // No point returning StateNone when it's not supposed to be used.
-        return //stateIndex == StateNone ? "None" :
-            stateIndex == StatePregame ? "Pregame" :
-            stateIndex == StateStarting ? "Starting" :
-            stateIndex == StateCountdown ? "Countdown" :
-            stateIndex == StatePlaying ? "Playing" :
-            stateIndex == StateEnding ? "Ending" :
-            stateIndex == STATEVOTING ? "Voting" :
+        static str collection[] = { "Pregame", "Starting", "Countdown", "Playing", "Ending", "Voting" };
+        KnownRoundStateT knownRoundState = GetKnownRoundStateTypeByIndex(index);
+        if (knownRoundState != STATENONE)
+            return collection[index];
             
-            // Should not be possible.
-            "Unknown";
+        // No known round state, return custom and the index.
+        return "Custom (" + str(index) + ")";
     }
 }
 

--- a/src/ZombieHorde2/acs_source/zh2game/roundtimer/roundtimer.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/roundtimer/roundtimer.acs
@@ -226,31 +226,26 @@ strict namespace RoundTimer
     internal KnownRoundTimerT GetKnownTypeOfIndex(int index)
     {
         static KnownRoundTimerT collection[] = { TIMERNONE, TIMERPREGAMECOUNTDOWN, TIMERCOUNTDOWN, TIMERPLAYING, TIMERENDING, TIMERVOTING, TIMERVOTED };
-        
-        // No known timer.
-        if (index < TIMERPREGAMECOUNTDOWN && index > TIMERVOTED)
-            return TIMERNONE;
+        foreach(KnownRoundTimerT item; collection)
+        {
+            if (index != item)
+                continue;
+            
+            return item;
+        }
 
-        return collection[index];
+        return TIMERNONE;
     }
 
     internal str GetTimerIndexAsString(int index)
     {
+        static str collection[] = { "Pregame Countdown", "Countdown", "Playing", "Ending", "Voting", "Voted" };
+        KnownRoundTimerT knownTimer = GetKnownTypeOfIndex(index);
+        if (knownTimer != TIMERNONE)
+            return collection[index];
+            
         // No known timer, return custom and the index.
-        if (index < TIMERPREGAMECOUNTDOWN || index > TIMERVOTED)
-            return "Custom (" + str(index) + ")";
-
-        // No point returning TIMERNONE when it's not supposed to be used.
-        return //index == TIMERNONE ? "None" :
-            index == TIMERPREGAMECOUNTDOWN ? "Pregame Countdown" :
-            index == TIMERCOUNTDOWN ? "Countdown":
-            index == TIMERPLAYING ? "Playing" :
-            index == TIMERENDING ? "Ending" :
-            index == TIMERVOTING ? "Voting" :
-            index == TIMERVOTED ? "Voted" :
-
-            // Should not be possible.
-            "Unknown";
+        return "Custom (" + str(index) + ")";
     }
 }
 


### PR DESCRIPTION
This fixes a bug that was introduced by the round state and round timer conversions.