### PR TITLE
ZE25 Instakill floor fix

### DIFF
--- a/mapsrc/ZombieHorde2Legacy/ZE25/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZE25/TEXTMAP
@@ -526655,7 +526655,7 @@ heightceiling = 1024;
 texturefloor = "FAN1";
 textureceiling = "F_SKY1";
 lightlevel = 255;
-special = 115;
+special = 80;
 nofallingdamage = true;
 }
 
@@ -570252,7 +570252,7 @@ heightceiling = 1024;
 texturefloor = "FAN1";
 textureceiling = "F_SKY1";
 lightlevel = 255;
-special = 115;
+special = 80;
 id = 279;
 nofallingdamage = true;
 }


### PR DESCRIPTION
Just before 1st resist, on the top of a bldg, there is a fan floor that instakill any player. Replaced with dmg 20.