### PR TITLE
Fix ZM02 Stuck at the bottom of the well & ZM08 Teleports fall damage.

### DIFF
--- a/mapsrc/ZombieHorde2Legacy/ZM02/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM02/TEXTMAP
@@ -9264,6 +9264,84 @@ class4 = true;
 class5 = true;
 }
 
+thing // 478
+{
+x = 1312.0;
+y = -2448.0;
+angle = 270;
+type = 9999;
+special = 226;
+arg0 = 3;
+skill1 = true;
+skill2 = true;
+skill3 = true;
+skill4 = true;
+skill5 = true;
+skill6 = true;
+skill7 = true;
+skill8 = true;
+single = true;
+coop = true;
+dm = true;
+class1 = true;
+class2 = true;
+class3 = true;
+class4 = true;
+class5 = true;
+}
+
+thing // 479
+{
+x = 1312.0;
+y = -2416.0;
+angle = 270;
+type = 9999;
+special = 226;
+arg0 = 3;
+skill1 = true;
+skill2 = true;
+skill3 = true;
+skill4 = true;
+skill5 = true;
+skill6 = true;
+skill7 = true;
+skill8 = true;
+single = true;
+coop = true;
+dm = true;
+class1 = true;
+class2 = true;
+class3 = true;
+class4 = true;
+class5 = true;
+}
+
+thing // 480
+{
+x = 1328.0;
+y = -2432.0;
+angle = 270;
+type = 9999;
+special = 226;
+arg0 = 3;
+skill1 = true;
+skill2 = true;
+skill3 = true;
+skill4 = true;
+skill5 = true;
+skill6 = true;
+skill7 = true;
+skill8 = true;
+single = true;
+coop = true;
+dm = true;
+class1 = true;
+class2 = true;
+class3 = true;
+class4 = true;
+class5 = true;
+}
+
 vertex // 0
 {
 x = -3584.0;

--- a/mapsrc/ZombieHorde2Legacy/ZM08/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM08/TEXTMAP
@@ -242724,6 +242724,7 @@ heightceiling = 472;
 texturefloor = "FLATNEW2";
 textureceiling = "F_SKY1";
 lightlevel = 207;
+nofallingdamage = true;
 }
 
 sector // 210
@@ -243188,6 +243189,7 @@ texturefloor = "FNEW4DR";
 textureceiling = "VOID";
 lightlevel = 127;
 id = 232;
+nofallingdamage = true;
 }
 
 sector // 261
@@ -243332,6 +243334,7 @@ heightceiling = 472;
 texturefloor = "MUD";
 textureceiling = "F_SKY1";
 lightlevel = 207;
+nofallingdamage = true;
 }
 
 sector // 277
@@ -247927,6 +247930,7 @@ heightceiling = 472;
 texturefloor = "FLATNEW2";
 textureceiling = "F_SKY1";
 lightlevel = 207;
+nofallingdamage = true;
 }
 
 sector // 772
@@ -247954,6 +247958,7 @@ heightceiling = 472;
 texturefloor = "FLATNEW2";
 textureceiling = "F_SKY1";
 lightlevel = 207;
+nofallingdamage = true;
 }
 
 sector // 775
@@ -250257,6 +250262,7 @@ texturefloor = "FWATER1";
 textureceiling = "VOID";
 lightlevel = 107;
 id = 1;
+nofallingdamage = true;
 }
 
 sector // 1023
@@ -250410,6 +250416,7 @@ texturefloor = "FNEW4DR";
 textureceiling = "VOID";
 lightlevel = 71;
 id = 61;
+nofallingdamage = true;
 }
 
 sector // 1039
@@ -250420,6 +250427,7 @@ texturefloor = "FLATNEW2";
 textureceiling = "VOID";
 lightlevel = 71;
 id = 61;
+nofallingdamage = true;
 }
 
 sector // 1040
@@ -250430,6 +250438,7 @@ texturefloor = "FLATNEW2";
 textureceiling = "VOID";
 lightlevel = 71;
 id = 61;
+nofallingdamage = true;
 }
 
 sector // 1041
@@ -250440,6 +250449,7 @@ texturefloor = "FLATNEW2";
 textureceiling = "VOID";
 lightlevel = 71;
 id = 61;
+nofallingdamage = true;
 }
 
 sector // 1042
@@ -250450,6 +250460,7 @@ texturefloor = "FLATNEW2";
 textureceiling = "VOID";
 lightlevel = 71;
 id = 61;
+nofallingdamage = true;
 }
 
 sector // 1043


### PR DESCRIPTION
ZM02:
Zombies could get stuck if they already used their 3 ZTELEs on the bottom of the well.
Simply fixed this by adding "actor hits the floor" and calling script 3 (which check if the player is a zombie, and teleport back the zombie in the play area).

ZM08:
Using the different teleports holes would result of dying/huge amount of falling damage. This is fixed by giving to the concerned sectors a "nofallingdamage" flags.