### PR TITLE
Fix some textures misalignment.

### DIFF
--- a/src/ZombieHorde2Legacy/textures.beta.zhtex
+++ b/src/ZombieHorde2Legacy/textures.beta.zhtex
@@ -91,22 +91,22 @@ Texture "CROFTPIC", 196, 236
 
 Texture "OLTX0230", 256, 256
 {
-    XScale 2.000
-    YScale 2.000
+    XScale 1.000
+    YScale 1.000
     Patch "OLTX0230", 0, 0
 }
 
 Texture "OLTX0234", 256, 512
 {
-    XScale 2.000
-    YScale 2.000
+    XScale 1.000
+    YScale 1.000
     Patch "OLTX0234", 0, 0
 }
 
 Texture "OLTX0235", 256, 512
 {
-    XScale 2.000
-    YScale 2.000
+    XScale 1.000
+    YScale 1.000
     Patch "OLTX0235", 0, 0
 }
 


### PR DESCRIPTION
This address #29 Sub issue 1.
The issue was: In ZH1, there is a HIRESTEX. In ZH2, we blindly copied and exported this with wrong scale.
But the reality was that in ZH 1, all the OLTX0230 to OLTX0235 are redefined right after with TX_START and TX_END creating this singular issue, overriding the scaling.

Put those textures back to the OG size as maps are brokenly displayed with the wrong texture size.