### PR TITLE
Fix textures part 2

### DIFF
--- a/mapsrc/ZombieHorde2Legacy/ZE02/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZE02/TEXTMAP
@@ -52422,7 +52422,7 @@ sidedef // 2919
 {
 sector = 111;
 offsetx = -32;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 2920
@@ -52433,7 +52433,7 @@ sector = 295;
 sidedef // 2921
 {
 sector = 111;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 2922
@@ -52444,8 +52444,8 @@ sector = 295;
 sidedef // 2923
 {
 sector = 111;
-offsetx = -32;
-texturebottom = "0522";
+offsetx = -16;
+texturebottom = "749";
 }
 
 sidedef // 2924
@@ -58146,7 +58146,7 @@ sector // 295
 {
 heightfloor = 600;
 heightceiling = 632;
-texturefloor = "0522";
+texturefloor = "748";
 textureceiling = "RBRIK5";
 lightlevel = 144;
 }

--- a/mapsrc/ZombieHorde2Legacy/ZE02B/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZE02B/TEXTMAP
@@ -90887,7 +90887,7 @@ texturebottom = "ROCK1_2";
 sidedef // 4558
 {
 sector = 661;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 4559
@@ -90898,7 +90898,7 @@ sector = 801;
 sidedef // 4560
 {
 sector = 661;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 4561
@@ -90930,7 +90930,7 @@ sidedef // 4565
 {
 sector = 661;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 4566

--- a/mapsrc/ZombieHorde2Legacy/ZE05/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZE05/TEXTMAP
@@ -110642,7 +110642,7 @@ sidedef // 3673
 {
 sector = 193;
 offsetx = 70;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3674
@@ -110653,7 +110653,7 @@ sector = 270;
 sidedef // 3675
 {
 sector = 193;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 3676
@@ -110665,7 +110665,7 @@ sidedef // 3677
 {
 sector = 193;
 offsetx = 70;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3678
@@ -110691,7 +110691,7 @@ sidedef // 3681
 {
 sector = 193;
 offsetx = -16;
-texturebottom = "0545";
+texturebottom = "746";
 }
 
 sidedef // 3682
@@ -110709,8 +110709,7 @@ texturemiddle = "N_MT5E18";
 sidedef // 3684
 {
 sector = 193;
-offsetx = -16;
-texturebottom = "0545";
+texturebottom = "746";
 }
 
 sidedef // 3685
@@ -110721,7 +110720,7 @@ sector = 271;
 sidedef // 3686
 {
 sector = 193;
-texturebottom = "0545";
+texturebottom = "745";
 }
 
 sidedef // 3687
@@ -127670,7 +127669,7 @@ sidedef // 6557
 {
 sector = 193;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 6558
@@ -127689,7 +127688,7 @@ sidedef // 6560
 {
 sector = 193;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "746";
 }
 
 sidedef // 6561
@@ -127701,7 +127700,7 @@ sidedef // 6562
 {
 sector = 193;
 offsetx = 64;
-texturebottom = "0545";
+texturebottom = "745";
 }
 
 sidedef // 6563
@@ -127720,7 +127719,7 @@ offsetx = 64;
 sidedef // 6565
 {
 sector = 193;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 6566

--- a/mapsrc/ZombieHorde2Legacy/ZE16/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZE16/TEXTMAP
@@ -174849,7 +174849,7 @@ sector // 414
 {
 heightfloor = -448;
 heightceiling = -285;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "FLAT5_4";
 lightlevel = 176;
 }
@@ -177814,7 +177814,7 @@ sector // 729
 {
 heightfloor = -448;
 heightceiling = -285;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "FLAT5_4";
 lightlevel = 176;
 }
@@ -177863,7 +177863,7 @@ sector // 734
 {
 heightfloor = -448;
 heightceiling = -285;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "FLAT5_4";
 lightlevel = 176;
 id = 38;
@@ -178983,7 +178983,7 @@ sector // 857
 {
 heightfloor = -448;
 heightceiling = -285;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "FLAT5_4";
 lightlevel = 176;
 id = 38;
@@ -178993,7 +178993,7 @@ sector // 858
 {
 heightfloor = -448;
 heightceiling = -285;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "FLAT5_4";
 lightlevel = 176;
 id = 38;
@@ -179956,7 +179956,7 @@ sector // 962
 {
 heightfloor = -448;
 heightceiling = -285;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "FLAT5_4";
 lightlevel = 176;
 id = 38;

--- a/mapsrc/ZombieHorde2Legacy/ZE19/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZE19/TEXTMAP
@@ -583310,7 +583310,7 @@ offsetx = 15;
 sidedef // 14902
 {
 sector = 2081;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 14903
@@ -655438,7 +655438,7 @@ sector = 3594;
 sidedef // 27316
 {
 sector = 3586;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 27317

--- a/mapsrc/ZombieHorde2Legacy/ZE23/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZE23/TEXTMAP
@@ -220755,7 +220755,7 @@ sidedef // 10277
 {
 sector = 1725;
 offsetx = 64;
-texturebottom = "0545";
+texturebottom = "749";
 }
 
 sidedef // 10278
@@ -220766,7 +220766,7 @@ sector = 1344;
 sidedef // 10279
 {
 sector = 1725;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 10280

--- a/mapsrc/ZombieHorde2Legacy/ZE25/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZE25/TEXTMAP
@@ -309601,6 +309601,7 @@ sidedef // 1694
 sector = 4671;
 offsetx = -32;
 texturebottom = "WOOD8";
+offsetx_bottom = -16.0;
 }
 
 sidedef // 1695
@@ -318751,6 +318752,7 @@ sidedef // 3196
 {
 sector = 4671;
 texturebottom = "WOOD8";
+offsetx_bottom = -16.0;
 }
 
 sidedef // 3197
@@ -348593,6 +348595,7 @@ sidedef // 8180
 {
 sector = 910;
 texturebottom = "ZHECM01";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 8181
@@ -348604,6 +348607,7 @@ sidedef // 8182
 {
 sector = 910;
 texturebottom = "ZHECM01";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 8183
@@ -348616,6 +348620,7 @@ sidedef // 8184
 {
 sector = 1948;
 texturebottom = "ZHECM01";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 8185
@@ -389753,6 +389758,7 @@ sidedef // 15238
 sector = 4715;
 offsetx = 16;
 texturebottom = "ZHECM01";
+offsetx_bottom = 48.0;
 }
 
 sidedef // 15239
@@ -389776,6 +389782,7 @@ sidedef // 15242
 {
 sector = 4715;
 texturebottom = "ZHECM01";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 15243
@@ -389787,6 +389794,7 @@ sidedef // 15244
 {
 sector = 4715;
 texturebottom = "ZHECM01";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 15245
@@ -389865,6 +389873,7 @@ sidedef // 15256
 sector = 2492;
 offsetx = -64;
 texturebottom = "ZHECM01";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 15257
@@ -389877,6 +389886,7 @@ sidedef // 15258
 sector = 2492;
 offsetx = -80;
 texturebottom = "ZHECM01";
+offsetx_bottom = 16.0;
 }
 
 sidedef // 15259
@@ -390869,6 +390879,7 @@ sidedef // 15448
 sector = 910;
 offsetx = 16;
 texturebottom = "ZHECM01";
+offsetx_bottom = 48.0;
 }
 
 sidedef // 15449
@@ -390892,6 +390903,7 @@ sidedef // 15452
 sector = 910;
 offsetx = 16;
 texturebottom = "ZHECM01";
+offsetx_bottom = 48.0;
 }
 
 sidedef // 15453
@@ -391166,6 +391178,7 @@ sidedef // 15506
 sector = 1948;
 offsetx = 32;
 texturebottom = "ZHECM01";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 15507
@@ -391178,6 +391191,7 @@ sidedef // 15508
 sector = 910;
 offsetx = 48;
 texturebottom = "ZHECM01";
+offsetx_bottom = 144.0;
 }
 
 sidedef // 15509
@@ -403213,6 +403227,7 @@ sidedef // 17596
 sector = 2492;
 offsetx = 64;
 texturebottom = "ZHECM01";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 17597
@@ -403615,6 +403630,7 @@ sidedef // 17676
 sector = 2205;
 offsetx = -176;
 texturebottom = "ZHECM01";
+offsetx_bottom = 240.0;
 }
 
 sidedef // 17677
@@ -403628,6 +403644,7 @@ sidedef // 17678
 sector = 2205;
 offsetx = -128;
 texturebottom = "ZHECM01";
+offsetx_bottom = 128.0;
 }
 
 sidedef // 17679
@@ -433872,6 +433889,7 @@ sidedef // 22927
 sector = 3520;
 offsetx = 128;
 texturebottom = "ZHECM01";
+offsetx_bottom = -128.0;
 }
 
 sidedef // 22928
@@ -433883,6 +433901,7 @@ sidedef // 22929
 {
 sector = 3520;
 texturebottom = "ZHECM01";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 22930
@@ -433896,6 +433915,7 @@ sidedef // 22931
 {
 sector = 2982;
 texturebottom = "ZHECM01";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 22932
@@ -433921,6 +433941,7 @@ sidedef // 22935
 {
 sector = 2939;
 texturebottom = "ZHECM01";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 22936
@@ -435668,6 +435689,7 @@ sidedef // 23215
 {
 sector = 2939;
 texturebottom = "ZHECM01";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 23216
@@ -435702,6 +435724,7 @@ sidedef // 23221
 {
 sector = 3520;
 texturebottom = "ZHECM01";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 23222
@@ -435732,6 +435755,8 @@ sidedef // 23226
 sector = 2982;
 offsetx = 4;
 texturebottom = "ZHECM01";
+offsetx_bottom = 12.0;
+offsetx_mid = 12.0;
 }
 
 sidedef // 23227
@@ -435743,6 +435768,7 @@ offsetx = 4;
 sidedef // 23228
 {
 sector = 2940;
+offsetx_mid = 240.0;
 }
 
 sidedef // 23229
@@ -435768,6 +435794,7 @@ sidedef // 23232
 sector = 2982;
 offsetx = 60;
 texturebottom = "ZHECM01";
+offsetx_bottom = 180.0;
 }
 
 sidedef // 23233
@@ -435797,6 +435824,7 @@ sidedef // 23237
 {
 sector = 2940;
 offsetx = 56;
+offsetx_mid = 168.0;
 }
 
 sidedef // 23238
@@ -435808,6 +435836,7 @@ texturebottom = "ZHECM04";
 sidedef // 23239
 {
 sector = 2985;
+offsetx_mid = 0.0;
 }
 
 sidedef // 23240
@@ -446797,6 +446826,7 @@ sidedef // 25133
 {
 sector = 3242;
 texturebottom = "ZHECM01";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 25134
@@ -447135,6 +447165,7 @@ sector = 3246;
 offsetx = 192;
 texturetop = "MFLR8_1";
 texturebottom = "ZHECM01";
+offsetx_bottom = -192.0;
 }
 
 sidedef // 25187
@@ -513582,6 +513613,7 @@ sidedef // 36236
 {
 sector = 2080;
 texturebottom = "ZHECM01";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 36237
@@ -513594,6 +513626,7 @@ sidedef // 36238
 sector = 2080;
 offsetx = 48;
 texturebottom = "ZHECM01";
+offsetx_bottom = 144.0;
 }
 
 sidedef // 36239

--- a/mapsrc/ZombieHorde2Legacy/ZM03/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM03/TEXTMAP
@@ -75008,7 +75008,7 @@ sidedef // 500
 {
 sector = 557;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 501
@@ -75081,8 +75081,7 @@ texturemiddle = "RWALL35";
 sidedef // 513
 {
 sector = 557;
-offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 514
@@ -75093,7 +75092,7 @@ sector = 772;
 sidedef // 515
 {
 sector = 557;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 516
@@ -75111,7 +75110,7 @@ texturemiddle = "RWALL35";
 sidedef // 518
 {
 sector = 557;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 519
@@ -75122,8 +75121,7 @@ sector = 773;
 sidedef // 520
 {
 sector = 557;
-offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 521
@@ -75211,7 +75209,7 @@ sidedef // 534
 {
 sector = 557;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 535
@@ -76633,7 +76631,7 @@ sidedef // 770
 {
 sector = 419;
 offsetx = 112;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 771
@@ -76645,7 +76643,7 @@ sidedef // 772
 {
 sector = 419;
 offsetx = 80;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 773
@@ -76657,7 +76655,7 @@ sidedef // 774
 {
 sector = 442;
 offsetx = 16;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 775
@@ -76670,7 +76668,7 @@ sidedef // 776
 {
 sector = 437;
 offsetx = 16;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 777
@@ -76683,7 +76681,7 @@ sidedef // 778
 {
 sector = 439;
 offsetx = 48;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 779
@@ -76695,7 +76693,7 @@ sidedef // 780
 {
 sector = 435;
 offsetx = 16;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 781
@@ -76708,7 +76706,7 @@ sidedef // 782
 {
 sector = 419;
 offsetx = 112;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 783
@@ -76720,7 +76718,7 @@ sidedef // 784
 {
 sector = 437;
 offsetx = 48;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 785
@@ -76733,7 +76731,7 @@ sidedef // 786
 {
 sector = 442;
 offsetx = 48;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 787
@@ -76745,7 +76743,7 @@ sidedef // 788
 {
 sector = 419;
 offsetx = 80;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 789
@@ -91073,7 +91071,7 @@ sidedef // 3231
 {
 sector = 276;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3232
@@ -91084,7 +91082,7 @@ sector = 285;
 sidedef // 3233
 {
 sector = 276;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 3234
@@ -91095,8 +91093,7 @@ sector = 285;
 sidedef // 3235
 {
 sector = 276;
-offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3236
@@ -91121,7 +91118,7 @@ sidedef // 3239
 {
 sector = 276;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3240
@@ -91132,7 +91129,7 @@ sector = 286;
 sidedef // 3241
 {
 sector = 276;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 3242
@@ -91143,8 +91140,7 @@ sector = 286;
 sidedef // 3243
 {
 sector = 276;
-offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3244
@@ -91169,7 +91165,7 @@ sidedef // 3247
 {
 sector = 276;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3248
@@ -91180,7 +91176,7 @@ sector = 287;
 sidedef // 3249
 {
 sector = 276;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 3250
@@ -91191,8 +91187,7 @@ sector = 287;
 sidedef // 3251
 {
 sector = 276;
-offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3252
@@ -91218,7 +91213,7 @@ sidedef // 3255
 {
 sector = 276;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3256
@@ -91229,7 +91224,7 @@ sector = 288;
 sidedef // 3257
 {
 sector = 276;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 3258
@@ -91240,8 +91235,7 @@ sector = 288;
 sidedef // 3259
 {
 sector = 276;
-offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3260
@@ -91554,7 +91548,7 @@ sidedef // 3307
 {
 sector = 293;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3308
@@ -91565,7 +91559,7 @@ sector = 295;
 sidedef // 3309
 {
 sector = 293;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 3310
@@ -91576,8 +91570,7 @@ sector = 295;
 sidedef // 3311
 {
 sector = 293;
-offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3312
@@ -91603,7 +91596,7 @@ sidedef // 3315
 {
 sector = 293;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3316
@@ -91614,7 +91607,7 @@ sector = 296;
 sidedef // 3317
 {
 sector = 293;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 3318
@@ -91625,8 +91618,7 @@ sector = 296;
 sidedef // 3319
 {
 sector = 293;
-offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3320
@@ -91646,13 +91638,15 @@ sidedef // 3322
 sector = 293;
 offsetx = 112;
 texturemiddle = "RWALL28";
+offsetx_mid = 81.0;
+offsety_mid = -67.0;
 }
 
 sidedef // 3323
 {
 sector = 293;
-offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
+offsetx_bottom = 16.0;
 }
 
 sidedef // 3324
@@ -91663,7 +91657,7 @@ sector = 297;
 sidedef // 3325
 {
 sector = 293;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 3326
@@ -91674,8 +91668,7 @@ sector = 297;
 sidedef // 3327
 {
 sector = 293;
-offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 3328
@@ -102019,7 +102012,7 @@ sidedef // 5041
 {
 sector = 293;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5042
@@ -102030,7 +102023,7 @@ sector = 415;
 sidedef // 5043
 {
 sector = 293;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5044
@@ -102041,8 +102034,7 @@ sector = 415;
 sidedef // 5045
 {
 sector = 293;
-offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5046
@@ -102253,7 +102245,7 @@ sidedef // 5078
 {
 sector = 439;
 offsetx = 48;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5079
@@ -102730,7 +102722,7 @@ sector = 426;
 sidedef // 5166
 {
 sector = 83;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5167
@@ -102741,7 +102733,7 @@ sector = 443;
 sidedef // 5168
 {
 sector = 83;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5169
@@ -102754,7 +102746,7 @@ sidedef // 5170
 {
 sector = 419;
 offsetx = -32;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5171
@@ -102765,7 +102757,7 @@ sector = 427;
 sidedef // 5172
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5173
@@ -102777,7 +102769,7 @@ offsetx = 112;
 sidedef // 5174
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5175
@@ -102788,7 +102780,7 @@ sector = 428;
 sidedef // 5176
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5177
@@ -102801,7 +102793,7 @@ sidedef // 5178
 {
 sector = 442;
 offsetx = -32;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5179
@@ -102813,7 +102805,7 @@ sidedef // 5180
 {
 sector = 419;
 offsetx = 80;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5181
@@ -102824,7 +102816,7 @@ sector = 433;
 sidedef // 5182
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5183
@@ -102835,7 +102827,7 @@ sector = 429;
 sidedef // 5184
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5185
@@ -102848,7 +102840,7 @@ sidedef // 5186
 {
 sector = 439;
 offsetx = -32;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5187
@@ -102860,7 +102852,7 @@ sidedef // 5188
 {
 sector = 419;
 offsetx = 80;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5189
@@ -102871,7 +102863,7 @@ sector = 430;
 sidedef // 5190
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5191
@@ -102882,7 +102874,7 @@ sector = 430;
 sidedef // 5192
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5193
@@ -102895,7 +102887,7 @@ sidedef // 5194
 {
 sector = 419;
 offsetx = -32;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5195
@@ -102906,7 +102898,7 @@ sector = 430;
 sidedef // 5196
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5197
@@ -102918,7 +102910,7 @@ offsetx = 112;
 sidedef // 5198
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5199
@@ -102929,7 +102921,7 @@ sector = 431;
 sidedef // 5200
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5201
@@ -102941,7 +102933,7 @@ sidedef // 5202
 {
 sector = 419;
 offsetx = -32;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5203
@@ -102952,7 +102944,7 @@ sector = 431;
 sidedef // 5204
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5205
@@ -102963,7 +102955,7 @@ sector = 431;
 sidedef // 5206
 {
 sector = 439;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5207
@@ -102974,7 +102966,7 @@ sector = 440;
 sidedef // 5208
 {
 sector = 439;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5209
@@ -102987,7 +102979,7 @@ sidedef // 5210
 {
 sector = 419;
 offsetx = -32;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5211
@@ -102998,7 +102990,7 @@ sector = 432;
 sidedef // 5212
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5213
@@ -103010,7 +103002,7 @@ offsetx = 80;
 sidedef // 5214
 {
 sector = 442;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5215
@@ -103021,7 +103013,7 @@ sector = 441;
 sidedef // 5216
 {
 sector = 442;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5217
@@ -103034,7 +103026,7 @@ sidedef // 5218
 {
 sector = 419;
 offsetx = -32;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5219
@@ -103045,7 +103037,7 @@ sector = 433;
 sidedef // 5220
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5221
@@ -103057,7 +103049,7 @@ offsetx = 80;
 sidedef // 5222
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5223
@@ -103068,7 +103060,7 @@ sector = 434;
 sidedef // 5224
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5225
@@ -103080,7 +103072,7 @@ sidedef // 5226
 {
 sector = 419;
 offsetx = -32;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 5227
@@ -103091,7 +103083,7 @@ sector = 434;
 sidedef // 5228
 {
 sector = 419;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5229
@@ -103138,7 +103130,7 @@ sidedef // 5236
 sector = 419;
 offsetx = 48;
 texturetop = "XP-VEN";
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5237
@@ -103163,7 +103155,7 @@ sidedef // 5240
 {
 sector = 419;
 texturetop = "XP-VEN";
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5241
@@ -103313,7 +103305,7 @@ sidedef // 5266
 sector = 419;
 offsetx = 16;
 texturetop = "XP-VEN";
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5267
@@ -103349,7 +103341,7 @@ sidedef // 5272
 {
 sector = 419;
 texturetop = "XP-VEN";
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5273
@@ -103375,7 +103367,7 @@ sidedef // 5276
 sector = 419;
 offsetx = 8;
 texturetop = "XP-VEN";
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5277
@@ -103482,7 +103474,7 @@ sidedef // 5294
 {
 sector = 419;
 offsetx = 80;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 5295
@@ -113553,8 +113545,7 @@ texturemiddle = "RWIND4";
 sidedef // 6991
 {
 sector = 353;
-offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 6992
@@ -113565,7 +113556,7 @@ sector = 692;
 sidedef // 6993
 {
 sector = 353;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 6994
@@ -113577,7 +113568,7 @@ sidedef // 6995
 {
 sector = 353;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 6996

--- a/mapsrc/ZombieHorde2Legacy/ZM04/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM04/TEXTMAP
@@ -80506,7 +80506,7 @@ texturemiddle = "BBRICK11";
 sidedef // 683
 {
 sector = 35;
-offsety = 290;
+offsety = 288;
 texturemiddle = "RWIND8";
 }
 
@@ -80646,7 +80646,7 @@ texturemiddle = "BROCK41";
 sidedef // 704
 {
 sector = 38;
-offsety = 290;
+offsety = 288;
 texturemiddle = "RWIND8";
 }
 
@@ -80757,7 +80757,7 @@ texturemiddle = "BROCK41";
 sidedef // 720
 {
 sector = 40;
-offsety = 290;
+offsety = 288;
 texturemiddle = "RWIND8";
 }
 

--- a/mapsrc/ZombieHorde2Legacy/ZM05/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM05/TEXTMAP
@@ -277803,7 +277803,7 @@ texturemiddle = "BBRICK11";
 sidedef // 16656
 {
 sector = 585;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 16657
@@ -277815,7 +277815,7 @@ sidedef // 16658
 {
 sector = 585;
 offsetx = -32;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 16659
@@ -277835,7 +277835,7 @@ sidedef // 16661
 {
 sector = 585;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 16662
@@ -277853,7 +277853,7 @@ texturemiddle = "BBRICK11";
 sidedef // 16664
 {
 sector = 585;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 16665
@@ -277866,7 +277866,7 @@ sidedef // 16666
 {
 sector = 585;
 offsetx = -32;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 16667
@@ -277885,7 +277885,7 @@ sidedef // 16669
 {
 sector = 585;
 offsetx = -16;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 16670
@@ -277903,7 +277903,7 @@ sidedef // 16672
 {
 sector = 585;
 offsetx = 128;
-texturebottom = "0545";
+texturebottom = "745";
 }
 
 sidedef // 16673
@@ -314132,7 +314132,7 @@ sector // 1681
 {
 heightfloor = -16;
 heightceiling = 80;
-texturefloor = "0522";
+texturefloor = "748";
 textureceiling = "BROCK41";
 lightlevel = 112;
 }
@@ -314141,7 +314141,7 @@ sector // 1682
 {
 heightfloor = -16;
 heightceiling = 80;
-texturefloor = "0522";
+texturefloor = "748";
 textureceiling = "BROCK41";
 lightlevel = 112;
 }

--- a/mapsrc/ZombieHorde2Legacy/ZM06/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM06/TEXTMAP
@@ -157580,7 +157580,7 @@ texturemiddle = "1089";
 sidedef // 1178
 {
 sector = 388;
-texturetop = "0522";
+texturetop = "747";
 }
 
 sidedef // 1179
@@ -169052,7 +169052,7 @@ texturemiddle = "0694";
 sidedef // 2946
 {
 sector = 442;
-texturetop = "0522";
+texturetop = "747";
 }
 
 sidedef // 2947
@@ -169279,7 +169279,7 @@ texturemiddle = "DOORSTOP";
 sidedef // 2982
 {
 sector = 442;
-texturetop = "0522";
+texturetop = "747";
 }
 
 sidedef // 2983

--- a/mapsrc/ZombieHorde2Legacy/ZM06/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM06/TEXTMAP
@@ -99015,6 +99015,7 @@ v2 = 2989;
 sidefront = 4907;
 sideback = 4908;
 twosided = true;
+dontpegbottom = true;
 dontdraw = true;
 }
 
@@ -133900,6 +133901,7 @@ v2 = 2988;
 sidefront = 11249;
 sideback = 11250;
 twosided = true;
+dontpegbottom = true;
 dontdraw = true;
 }
 
@@ -181105,6 +181107,8 @@ sidedef // 4907
 {
 sector = 1137;
 offsetx = 1952;
+texturebottom = "1086";
+offsetx_bottom = -112.0;
 }
 
 sidedef // 4908
@@ -219131,6 +219135,8 @@ sidedef // 11249
 {
 sector = 720;
 offsetx = 1936;
+texturebottom = "1086";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 11250

--- a/mapsrc/ZombieHorde2Legacy/ZM11/SCRIPTS
+++ b/mapsrc/ZombieHorde2Legacy/ZM11/SCRIPTS
@@ -10,8 +10,8 @@
 Script "zm11_open" // Level Setups
 {
 	Sector_setcolor(17, 0, 200, 0);
-	SetLineSpecial(26, 80, 4, 0, 26);
-	TranslucentLine(26, 96, 0);
+	//SetLineSpecial(26, 80, 4, 0, 26); //ZH2 AQW Issue #29
+	//TranslucentLine(26, 96, 0); //ZH2 AQW Issue #29
 
 	if(random(0,1))
 		Acs_Execute(6, 0);

--- a/mapsrc/ZombieHorde2Legacy/ZM11/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM11/TEXTMAP
@@ -122098,9 +122098,13 @@ v2 = 5246;
 sidefront = 11309;
 sideback = 11310;
 id = 26;
+special = 80;
+arg0 = 4;
+arg2 = 26;
 twosided = true;
 blockeverything = true;
 impact = true;
+alpha = 0.38;
 }
 
 linedef // 5972

--- a/mapsrc/ZombieHorde2Legacy/ZM11/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM11/TEXTMAP
@@ -252113,7 +252113,7 @@ sector = 1722;
 sidedef // 14908
 {
 sector = 1651;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 14909
@@ -255653,7 +255653,7 @@ sector = 1789;
 sidedef // 15505
 {
 sector = 1651;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 15506
@@ -255699,7 +255699,7 @@ sector = 1790;
 sidedef // 15513
 {
 sector = 1651;
-texturebottom = "0545";
+texturebottom = "745";
 }
 
 sidedef // 15514

--- a/mapsrc/ZombieHorde2Legacy/ZM14/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM14/TEXTMAP
@@ -366521,7 +366521,7 @@ texturemiddle = "0519";
 sidedef // 2392
 {
 sector = 349;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 2393
@@ -366649,7 +366649,7 @@ sector = 365;
 sidedef // 2412
 {
 sector = 363;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 2413
@@ -366845,7 +366845,7 @@ texturemiddle = "0519";
 sidedef // 2442
 {
 sector = 369;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 2443
@@ -367499,7 +367499,7 @@ sidedef // 2552
 {
 sector = 385;
 offsetx = 64;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 2553
@@ -373363,7 +373363,7 @@ texturemiddle = "BBRWN11";
 sidedef // 3513
 {
 sector = 538;
-texturemiddle = "0522";
+texturemiddle = "750";
 }
 
 sidedef // 3514
@@ -373405,7 +373405,7 @@ texturemiddle = "BBRWN11";
 sidedef // 3519
 {
 sector = 539;
-texturemiddle = "0522";
+texturemiddle = "750";
 }
 
 sidedef // 3520
@@ -373476,7 +373476,7 @@ texturemiddle = "DOORTRAK";
 sidedef // 3529
 {
 sector = 540;
-texturetop = "0522";
+texturetop = "750";
 }
 
 sidedef // 3530
@@ -576452,8 +576452,9 @@ offsetx_mid = 32.0;
 sidedef // 37946
 {
 sector = 1972;
-texturebottom = "0545";
+texturebottom = "745";
 texturemiddle = "N_GRT02A";
+offsety_bottom = 64.0;
 }
 
 sidedef // 37947
@@ -598115,7 +598116,7 @@ sector // 360
 {
 heightfloor = 216;
 heightceiling = 248;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "0_RUS14";
 lightlevel = 48;
 rotationceiling = 90.0;
@@ -598176,7 +598177,7 @@ sector // 366
 {
 heightfloor = 216;
 heightceiling = 248;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "0_RUS14";
 lightlevel = 48;
 rotationceiling = 90.0;
@@ -598236,7 +598237,7 @@ sector // 372
 {
 heightfloor = 216;
 heightceiling = 248;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "0_RUS14";
 lightlevel = 48;
 rotationceiling = 90.0;
@@ -612224,7 +612225,7 @@ sector // 1851
 {
 heightfloor = 224;
 heightceiling = 256;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "BBRWZ04";
 lightlevel = 80;
 id = 57;
@@ -612294,7 +612295,7 @@ sector // 1858
 {
 heightfloor = 224;
 heightceiling = 256;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "BBRWZ04";
 lightlevel = 80;
 id = 57;
@@ -612314,7 +612315,7 @@ sector // 1860
 {
 heightfloor = 224;
 heightceiling = 256;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "BBRWZ04";
 lightlevel = 80;
 id = 57;
@@ -612324,7 +612325,7 @@ sector // 1861
 {
 heightfloor = 224;
 heightceiling = 256;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "BBRWZ04";
 lightlevel = 80;
 id = 57;
@@ -612452,7 +612453,7 @@ sector // 1874
 {
 heightfloor = 224;
 heightceiling = 256;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "BBRWZ04";
 lightlevel = 80;
 id = 57;
@@ -612462,7 +612463,7 @@ sector // 1875
 {
 heightfloor = 224;
 heightceiling = 256;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "BBRWZ04";
 lightlevel = 80;
 id = 57;
@@ -612492,7 +612493,7 @@ sector // 1878
 {
 heightfloor = 224;
 heightceiling = 256;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "BBRWZ04";
 lightlevel = 80;
 id = 57;
@@ -612502,7 +612503,7 @@ sector // 1879
 {
 heightfloor = 224;
 heightceiling = 256;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "BBRWZ04";
 lightlevel = 80;
 id = 57;
@@ -612631,7 +612632,7 @@ sector // 1892
 {
 heightfloor = 224;
 heightceiling = 256;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "BBRWZ04";
 lightlevel = 80;
 id = 57;
@@ -612642,7 +612643,7 @@ sector // 1893
 {
 heightfloor = 224;
 heightceiling = 256;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "BBRWZ04";
 lightlevel = 80;
 id = 57;
@@ -612663,7 +612664,7 @@ sector // 1895
 {
 heightfloor = 224;
 heightceiling = 256;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "BBRWZ04";
 lightlevel = 80;
 id = 57;
@@ -612674,7 +612675,7 @@ sector // 1896
 {
 heightfloor = 224;
 heightceiling = 256;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "BBRWZ04";
 lightlevel = 80;
 id = 57;
@@ -648947,7 +648948,7 @@ sector // 5595
 {
 heightfloor = 480;
 heightceiling = 512;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "RWALL11";
 lightlevel = 128;
 id = 127;

--- a/mapsrc/ZombieHorde2Legacy/ZM18/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM18/TEXTMAP
@@ -136583,7 +136583,8 @@ sector = 26;
 sidedef // 197
 {
 sector = 0;
-texturebottom = "0522";
+offsetx = 3;
+texturebottom = "750";
 }
 
 sidedef // 198
@@ -136594,7 +136595,7 @@ sector = 27;
 sidedef // 199
 {
 sector = 0;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 200
@@ -136612,7 +136613,7 @@ texturemiddle = "SILVER1";
 sidedef // 202
 {
 sector = 0;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 203
@@ -136703,7 +136704,8 @@ sector = 29;
 sidedef // 217
 {
 sector = 29;
-texturebottom = "0522";
+offsetx = 3;
+texturebottom = "750";
 }
 
 sidedef // 218
@@ -137087,9 +137089,7 @@ sector = 39;
 sidedef // 284
 {
 sector = 36;
-offsetx = 5;
-offsety = 31;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 285
@@ -137101,7 +137101,7 @@ offsetx = 92;
 sidedef // 286
 {
 sector = 36;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 287
@@ -137119,7 +137119,7 @@ texturemiddle = "SILVER1";
 sidedef // 289
 {
 sector = 36;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 290
@@ -137210,7 +137210,7 @@ sector = 42;
 sidedef // 304
 {
 sector = 42;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 305
@@ -137604,8 +137604,7 @@ sidedef // 372
 {
 sector = 49;
 offsetx = 3;
-offsety = 31;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 373
@@ -137616,7 +137615,7 @@ sector = 53;
 sidedef // 374
 {
 sector = 49;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 375
@@ -137634,7 +137633,7 @@ texturemiddle = "SILVER1";
 sidedef // 377
 {
 sector = 49;
-texturebottom = "0522";
+texturebottom = "749";
 }
 
 sidedef // 378
@@ -138016,9 +138015,7 @@ sector = 49;
 sidedef // 444
 {
 sector = 36;
-offsetx = 101;
-offsety = 31;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 445
@@ -138029,7 +138026,8 @@ sector = 40;
 sidedef // 446
 {
 sector = 0;
-texturebottom = "0522";
+offsetx = 3;
+texturebottom = "750";
 }
 
 sidedef // 447
@@ -139475,9 +139473,7 @@ texturemiddle = "N_LTRD03";
 sidedef // 697
 {
 sector = 2;
-offsetx = 5;
-offsety = 31;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 698
@@ -139488,7 +139484,7 @@ sector = 100;
 sidedef // 699
 {
 sector = 2;
-texturebottom = "0545";
+texturebottom = "749";
 }
 
 sidedef // 700
@@ -139506,7 +139502,7 @@ texturemiddle = "SHAWN2";
 sidedef // 702
 {
 sector = 2;
-texturebottom = "0545";
+texturebottom = "749";
 }
 
 sidedef // 703
@@ -139524,9 +139520,8 @@ texturemiddle = "SHAWN2";
 sidedef // 705
 {
 sector = 1501;
-offsetx = 5;
-offsety = 31;
-texturebottom = "0522";
+offsety = 32;
+texturebottom = "745";
 }
 
 sidedef // 706
@@ -139537,7 +139532,8 @@ sector = 101;
 sidedef // 707
 {
 sector = 1501;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 708
@@ -139555,7 +139551,8 @@ texturemiddle = "SHAWN2";
 sidedef // 710
 {
 sector = 1501;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 711
@@ -139787,7 +139784,8 @@ texturemiddle = "0_RUS22";
 sidedef // 749
 {
 sector = 1456;
-texturebottom = "0522";
+offsety = 32;
+texturebottom = "745";
 }
 
 sidedef // 750
@@ -140023,7 +140021,8 @@ texturemiddle = "SILVER1";
 sidedef // 787
 {
 sector = 1451;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 788
@@ -143955,7 +143954,8 @@ texturetop = "FLAT14-Y";
 sidedef // 1450
 {
 sector = 1450;
-texturebottom = "0522";
+offsety = 32;
+texturebottom = "745";
 }
 
 sidedef // 1451
@@ -143967,7 +143967,8 @@ offsetx = 20;
 sidedef // 1452
 {
 sector = 1499;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 1453
@@ -143989,7 +143990,8 @@ texturetop = "FLAT14-Y";
 sidedef // 1456
 {
 sector = 1450;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 1457
@@ -145901,7 +145903,8 @@ texturemiddle = "SILVER1";
 sidedef // 1779
 {
 sector = 1456;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 1780
@@ -145968,7 +145971,8 @@ texturemiddle = "SILVER1";
 sidedef // 1789
 {
 sector = 1456;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 1790
@@ -149175,7 +149179,8 @@ texturemiddle = "SILVER1";
 sidedef // 2322
 {
 sector = 1453;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 2323
@@ -164406,7 +164411,8 @@ texturemiddle = "SILVER1";
 sidedef // 4856
 {
 sector = 296;
-texturebottom = "0522";
+offsety = 32;
+texturebottom = "745";
 }
 
 sidedef // 4857
@@ -164418,7 +164424,8 @@ texturetop = "FLAT14-Y";
 sidedef // 4858
 {
 sector = 296;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 4859
@@ -164437,7 +164444,8 @@ texturemiddle = "SILVER1";
 sidedef // 4861
 {
 sector = 296;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 4862
@@ -172297,7 +172305,8 @@ texturemiddle = "SILVER1";
 sidedef // 6223
 {
 sector = 264;
-texturebottom = "0522";
+offsety = 32;
+texturebottom = "745";
 }
 
 sidedef // 6224
@@ -172308,7 +172317,8 @@ sector = 808;
 sidedef // 6225
 {
 sector = 264;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 6226
@@ -172319,7 +172329,8 @@ sector = 808;
 sidedef // 6227
 {
 sector = 264;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 6228
@@ -183705,7 +183716,8 @@ texturemiddle = "SHAWN2";
 sidedef // 8239
 {
 sector = 1494;
-texturebottom = "0522";
+offsety = 32;
+texturebottom = "745";
 }
 
 sidedef // 8240
@@ -183716,7 +183728,8 @@ sector = 1059;
 sidedef // 8241
 {
 sector = 1494;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 8242
@@ -183727,7 +183740,8 @@ sector = 1059;
 sidedef // 8243
 {
 sector = 1494;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 8244
@@ -186210,7 +186224,8 @@ texturemiddle = "SILVER1";
 sidedef // 8674
 {
 sector = 238;
-texturebottom = "0522";
+offsety = 32;
+texturebottom = "745";
 }
 
 sidedef // 8675
@@ -186221,7 +186236,8 @@ sector = 1100;
 sidedef // 8676
 {
 sector = 238;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "745";
 }
 
 sidedef // 8677
@@ -186232,7 +186248,8 @@ sector = 1100;
 sidedef // 8678
 {
 sector = 238;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "745";
 }
 
 sidedef // 8679
@@ -186257,7 +186274,8 @@ texturemiddle = "SILVER1";
 sidedef // 8682
 {
 sector = 238;
-texturebottom = "0522";
+offsety = 32;
+texturebottom = "745";
 }
 
 sidedef // 8683
@@ -186268,7 +186286,8 @@ sector = 1101;
 sidedef // 8684
 {
 sector = 238;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 8685
@@ -186279,7 +186298,8 @@ sector = 1101;
 sidedef // 8686
 {
 sector = 238;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 8687
@@ -202119,7 +202139,8 @@ texturemiddle = "SILVER1";
 sidedef // 11396
 {
 sector = 1451;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 11397
@@ -202130,7 +202151,8 @@ sector = 114;
 sidedef // 11398
 {
 sector = 1451;
-texturebottom = "0522";
+offsety = 32;
+texturebottom = "745";
 }
 
 sidedef // 11399
@@ -202160,7 +202182,8 @@ texturemiddle = "SILVER1";
 sidedef // 11403
 {
 sector = 1452;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 11404
@@ -202171,7 +202194,8 @@ sector = 770;
 sidedef // 11405
 {
 sector = 1452;
-texturebottom = "0522";
+offsety = 32;
+texturebottom = "745";
 }
 
 sidedef // 11406
@@ -202182,7 +202206,8 @@ sector = 770;
 sidedef // 11407
 {
 sector = 1452;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 11408
@@ -202212,7 +202237,8 @@ texturemiddle = "SILVER1";
 sidedef // 11412
 {
 sector = 1453;
-texturebottom = "0545";
+offsety = 32;
+texturebottom = "746";
 }
 
 sidedef // 11413
@@ -202223,7 +202249,8 @@ sector = 769;
 sidedef // 11414
 {
 sector = 1453;
-texturebottom = "0522";
+offsety = 32;
+texturebottom = "745";
 }
 
 sidedef // 11415
@@ -204191,8 +204218,9 @@ texturetop = "FLAT14-Y";
 sidedef // 11750
 {
 sector = 1499;
-offsetx = 12;
-texturebottom = "0522";
+offsety = 32;
+texturebottom = "745";
+offsetx_bottom = 12.0;
 }
 
 sidedef // 11751

--- a/mapsrc/ZombieHorde2Legacy/ZM21/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM21/TEXTMAP
@@ -284734,6 +284734,7 @@ v1 = 14416;
 v2 = 14417;
 sidefront = 34216;
 sideback = 34217;
+twosided = true;
 }
 
 linedef // 18456

--- a/mapsrc/ZombieHorde2Legacy/ZM25/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM25/TEXTMAP
@@ -16277,7 +16277,7 @@ class5 = true;
 
 thing // 715
 {
-x = -856.0;
+x = -872.0;
 y = 7352.0;
 angle = 270;
 type = 28099;
@@ -152875,6 +152875,7 @@ arg1 = 64;
 twosided = true;
 dontpegbottom = true;
 playeruse = true;
+locknumber = 5;
 }
 
 linedef // 9007

--- a/mapsrc/ZombieHorde2Modern/ZE05M/TEXTMAP
+++ b/mapsrc/ZombieHorde2Modern/ZE05M/TEXTMAP
@@ -191462,7 +191462,7 @@ sector = 270;
 sidedef // 3627
 {
 sector = 193;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 3628
@@ -191525,7 +191525,7 @@ sector = 271;
 sidedef // 3637
 {
 sector = 193;
-texturebottom = "0545";
+texturebottom = "745";
 }
 
 sidedef // 3638
@@ -208174,7 +208174,7 @@ sidedef // 6515
 {
 sector = 193;
 offsetx = 64;
-texturebottom = "0545";
+texturebottom = "745";
 }
 
 sidedef // 6516
@@ -208193,7 +208193,7 @@ offsetx = 64;
 sidedef // 6518
 {
 sector = 193;
-texturebottom = "0522";
+texturebottom = "750";
 }
 
 sidedef // 6519

--- a/mapsrc/ZombieHorde2Modern/ZE08M/TEXTMAP
+++ b/mapsrc/ZombieHorde2Modern/ZE08M/TEXTMAP
@@ -557293,7 +557293,7 @@ sector // 2642
 {
 heightfloor = -64;
 heightceiling = -32;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "RWALL15";
 lightlevel = 144;
 }
@@ -573665,7 +573665,7 @@ sector // 4372
 {
 heightfloor = -64;
 heightceiling = -32;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "RWALL15";
 lightlevel = 144;
 }
@@ -573674,7 +573674,7 @@ sector // 4373
 {
 heightfloor = -64;
 heightceiling = -32;
-texturefloor = "0545";
+texturefloor = "748";
 textureceiling = "RWALL15";
 lightlevel = 144;
 }

--- a/mapsrc/ZombieHorde2Modern/ZM04M/TEXTMAP
+++ b/mapsrc/ZombieHorde2Modern/ZM04M/TEXTMAP
@@ -147855,6 +147855,7 @@ heightceiling = 336;
 texturefloor = "CRATINY";
 textureceiling = "BBRWZ04";
 lightlevel = 128;
+ypanningfloor = 8.0;
 }
 
 sector // 621

--- a/mapsrc/ZombieHorde2Modern/ZM04M/TEXTMAP
+++ b/mapsrc/ZombieHorde2Modern/ZM04M/TEXTMAP
@@ -90783,14 +90783,14 @@ texturemiddle = "BBRICK11";
 sidedef // 688
 {
 sector = 35;
-offsety = 290;
+offsety = 288;
 texturemiddle = "RWIND8";
 }
 
 sidedef // 689
 {
 sector = 33;
-offsety = 256;
+offsety = 288;
 texturemiddle = "RWIND8";
 }
 
@@ -90928,14 +90928,14 @@ texturemiddle = "BROCK41";
 sidedef // 709
 {
 sector = 38;
-offsety = 290;
+offsety = 288;
 texturemiddle = "RWIND8";
 }
 
 sidedef // 710
 {
 sector = 37;
-offsety = 256;
+offsety = 288;
 texturemiddle = "RWIND8";
 }
 
@@ -91043,14 +91043,14 @@ texturemiddle = "BROCK41";
 sidedef // 725
 {
 sector = 40;
-offsety = 290;
+offsety = 288;
 texturemiddle = "RWIND8";
 }
 
 sidedef // 726
 {
 sector = 39;
-offsety = 256;
+offsety = 288;
 texturemiddle = "RWIND8";
 }
 

--- a/src/ZombieHorde2Legacy/textures.drresources
+++ b/src/ZombieHorde2Legacy/textures.drresources
@@ -176,15 +176,25 @@ WallTexture "0519", 128, 128
     Patch "0519", 0, 0
 }
 
-WallTexture "0522", 64, 32
-{
-    Patch "0545", 0, 0
-}
+//AQW This is completely fucked up
+//I hate it so much; Some explaination
+//0522 Is the locker texture, 64px wide, 32 px tall.
+//0545 Is the side of that locker texture. 64px wide, 32 px tall.
+//745 is the full height of the locker texture.
+//746 is the full height of the side of the locker texture
+//MIND YOU, ALL OF THIS IS FROM 0545 TEXTURE.
+//BUT THERE IS AN EXISTING 0522 Texture, WHICH IS A TRIPLE LOCKER , HEIGHT OF 96px.
+//This whole thing is because we replace a texture with the same name by using the stich/cut method.
 
-WallTexture "0545", 32, 32
-{
-    Patch "0545", -64, 0
-}
+//WallTexture "0522", 64, 32
+//{
+//    Patch "0545", 0, 0
+//}
+
+//WallTexture "0545", 32, 32
+//{
+//    Patch "0545", -64, 0
+//}
 
 WallTexture "0689", 128, 128
 {
@@ -216,6 +226,28 @@ WallTexture "746", 32, 96
 {
     Patch "textures/legacy/drresources/0545", -64, 0
 }
+
+//AQW: same as the "0522" defined above. So this is for the stich&cut of "0545"
+WallTexture "747", 64, 32
+{
+    Patch "0545", 0, 0
+}
+
+WallTexture "748", 32, 32
+{
+    Patch "0545", -64, 0
+}
+//AQW: So this is for the stich&cut of "0522"
+WallTexture "749", 32, 96
+{
+    Patch "0522", -64, 0
+}
+
+WallTexture "750", 64, 96
+{
+    Patch "0522", 0, 0
+}
+// End of Notice
 
 WallTexture "0062", 64, 64
 {


### PR DESCRIPTION
Originally, this branch aimed to fix the texture misalignment.
This is what it aims to do (I was following issue #29 )  UNTIL ZM18.

ZM18 showed there was a HUGE problem with texture definition with 0545 & 0522.
As seen in ffd3335836a30fdaffd061cc39d21915a6f4d90c.
Here's the issue.
There is 2 textures already existing. 0522.png & 0545.png (There is also a duplicate but this will be fixed after this merged).
But in TEXTURES, we redefine 0545 & 0522 From 0545... WITH THE SAME NAME.
This create overwrite issue, and also it makes the mappers lose around 4 Textures.

So to fix this, because some mapper might use the original 0545 & 0522, I let them as is, and added new textures from the original ones:
747,748,749 and 750. (Because there are 2 different heights of the locker texture, and there is also a side texture for each version).

Now, the big question is how this change impacted the whole map set? 
Well a LOT.
So in this PR, all the side effect of not properly attributing this texture name is also RESOLVED.

Hope this fix suits you.