### PR TITLE
New clientsided lock system

### DIFF
--- a/libsrc/acs_source/trackedproperties/trackedproperties.acs
+++ b/libsrc/acs_source/trackedproperties/trackedproperties.acs
@@ -6,6 +6,8 @@
 
 // Small little util to track certain properties in the case they can trigger multiple times subsequently.
 
+// NOTE: This system is currently unused.
+
 strict namespace TrackedProperties
 {
     bool AddProperty(int index)

--- a/src/ZombieHorde2/acs_source/zh2game/admin/admin.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/admin/admin.acs
@@ -89,9 +89,7 @@ strict namespace Admin
     {
         ZH2Game::GameContext.HasAdminHudOpen = set;
         Hud::SetCursorEnabled(set);
-
-        if (!NamedRequestScriptPuke("zh2_internal_menu_admin_request_set_frozen", int(set)))
-            Logger::LogError(LogSource, "Failed to set frozen state on player for admin hud.");
+        Player::LockMovement(set);
     }
 }
 

--- a/src/ZombieHorde2/acs_source/zh2game/admin/hudactions.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/admin/hudactions.acs
@@ -6,16 +6,6 @@
 
 strict namespace Admin
 {
-    // Called from the client to set/unset freeze.
-    script "zh2_internal_menu_admin_request_set_frozen" (int set) net
-    {
-        if (!GetAdmin()) terminate;
-
-        if (set && TrackedProperties::AddProperty((int)TrackedProperties::TRACKED_TOTALLYFROZEN)
-            || !set && TrackedProperties::RemoveProperty((int)TrackedProperties::TRACKED_TOTALLYFROZEN))
-            SetPlayerProperty(0, set, PROP_TOTALLYFROZEN);
-    }
-
     internal void AdminInfectPlayerClientside(int id)
     {
         if (!NamedRequestScriptPuke("zh2_internal_menu_action_infect", id))

--- a/src/ZombieHorde2/acs_source/zh2game/binds.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/binds.acs
@@ -152,6 +152,11 @@ strict namespace ZH2Game
 
     /* DEBUG - GENERAL */
 
+    script "zh2_action_unlockplayer" net
+    {
+        Player::LockMovement(false);
+    }
+
     script "zh2_action_debuggivestartweapons" net
     {
         // Can't be called when not offline, not in development and we are not admin.

--- a/src/ZombieHorde2/acs_source/zh2game/decorate/decorate.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/decorate/decorate.acs
@@ -25,7 +25,6 @@ strict namespace Decorate
             TakeChaingunHeat();
 
         TakeJacksGunSmoke();
-        CanFireTic();
 
         // The player is on fire.
         if (IsOnFire())

--- a/src/ZombieHorde2/acs_source/zh2game/decorate/weaponfiring.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/decorate/weaponfiring.acs
@@ -4,27 +4,6 @@
 
 strict namespace Decorate
 {
-    /* CAN FIRE */
-
-    // Handles if the player can fire. You can't fire when the round ended.
-
-    internal void CanFireTic()
-    {
-        // Check if we should update the player's inventory with the item.
-        // This is then synched to the client and they will properly block the weapon from firing.
-        BCSUtils::SetInventory(WEAPON_BLOCK_FIRING_ITEM, (int)!GetCanFire());
-    }
-
-    internal bool GetCanFire()
-    {
-        return GetPlayerCanFire(PlayerNumber());
-    }
-
-    internal bool GetPlayerCanFire(int id)
-    {
-        return Round::GetActiveKnownRoundState() < Round::STATEENDING;
-    }
-
     /* FIRING */
 
     internal int GetFiringTime()

--- a/src/ZombieHorde2/acs_source/zh2game/events.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/events.acs
@@ -314,7 +314,6 @@ strict namespace ZH2Game
                 }
                 else Logger::LogError(LogSource, "Missing required ending timer.");
 
-                // Reset all powers. Removes excess visual noise.
                 for (int i = 0; i < BCSUtils::MAX_PLAYERS; ++i)
                 {
                     if (!PlayerInGame(i))
@@ -324,7 +323,12 @@ strict namespace ZH2Game
                     if (!BCSUTILS::ActorIsAlive(tid))
                         continue;
 
+                    // Reset all powers. Removes excess visual noise.
                     Power::ResetPlayerPowers(i);
+
+                    // Prevent from firing.
+                    // TODO: Look into where this can be unset again? Should the state change somehow.
+                    BCSUtils::SetActorInventory(tid, WEAPON_BLOCK_FIRING_ITEM, 1);
                 }
 
                 // Reward a random player.

--- a/src/ZombieHorde2/acs_source/zh2game/gameloop/playerloop.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/gameloop/playerloop.acs
@@ -48,6 +48,7 @@ strict namespace GameLoop
             Weather::TicClient();
             RoundTimer::TicClient();
             Game::FullServerTicClient();
+            Player::LockTic();
             Player::HeartbeatTicClient();
             Player::TranslucentAlliesTicClient();
             Game::ClientDeathCamTic();

--- a/src/ZombieHorde2/acs_source/zh2game/main.h.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/main.h.acs
@@ -86,6 +86,12 @@ strict namespace ZH2Game
         // Serverside. If `true`, the join prevention depeding on round state is ignored.
         bool AlwaysAllowJoin;
 
+        // Clientside. If `true`, the game locks the player's angle and pitch.
+        // The added angle and pitch values are then enforces.
+        bool LockMovement;
+        fixed LockedAngle;
+        fixed LockedPitch;
+
         // Synced when a match ends to indicate what specie won the round.
         Game::WinningSpecieT WinningSpecie;
 

--- a/src/ZombieHorde2/acs_source/zh2game/player/lock.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/lock.acs
@@ -15,7 +15,7 @@ strict namespace Player
 
     internal void LockMovement(bool lock)
     {
-        VALIDATE_IS_SERVERSIDE_FUNCTION();
+        VALIDATE_IS_CLIENTSIDE_FUNCTION();
 
         ZH2Game::GameContext.LockMovement = lock;
         ZH2Game::GameContext.LockedAngle = GetActorAngle(Identity::GetTid(ConsolePlayerNumber()));
@@ -46,7 +46,7 @@ strict namespace Player
         bool add = (bool)addRaw;
 
         // Check if we should remove the block. We do always allow adding the block.
-        if (!add && !Decorate::GetCanFire())
+        if (!add && Round::GetActiveKnownRoundState() >= Round::STATEENDING)
             terminate;
 
         BCSUtils::SetInventory(WEAPON_BLOCK_FIRING_ITEM, (int)add);

--- a/src/ZombieHorde2/acs_source/zh2game/player/lock.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/lock.acs
@@ -1,0 +1,54 @@
+#ifdef __IMPORTED__
+    #error This file must be #included.
+#endif
+
+strict namespace Player
+{
+    internal void LockTic()
+    {
+        if (!GetLockMovement())
+            return;
+
+        SetActorAngle(ActivatorTid(), GetLockAngle());
+        SetActorPitch(ActivatorTid(), GetLockPitch());
+    }
+
+    internal void LockMovement(bool lock)
+    {
+        VALIDATE_IS_SERVERSIDE_FUNCTION();
+
+        ZH2Game::GameContext.LockMovement = lock;
+        ZH2Game::GameContext.LockedAngle = GetActorAngle(Identity::GetTid(ConsolePlayerNumber()));
+        ZH2Game::GameContext.LockedPitch = GetActorPitch(Identity::GetTid(ConsolePlayerNumber()));
+
+        if (!NamedRequestScriptPuke("zh2_internal_lock_movement_block_weapon_firing", int(lock)))
+            Logger::LogError(LogSource, "Failed to call internal block weapon firing script.");
+    }
+
+    internal bool GetLockMovement()
+    {
+        return ZH2Game::GameContext.LockMovement;
+    }
+
+    internal fixed GetLockAngle()
+    {
+        return ZH2Game::GameContext.LockedAngle;
+    }
+
+    internal fixed GetLockPitch()
+    {
+        return ZH2Game::GameContext.LockedPitch;
+    }
+
+    // This gives the inventory item to block weapon firing. Sadly I can't prevent this clientside.
+    script "zh2_internal_lock_movement_block_weapon_firing" (raw addRaw) net
+    {
+        bool add = (bool)addRaw;
+
+        // Check if we should remove the block. We do always allow adding the block.
+        if (!add && !Decorate::GetCanFire())
+            terminate;
+
+        BCSUtils::SetInventory(WEAPON_BLOCK_FIRING_ITEM, (int)add);
+    }
+}

--- a/src/ZombieHorde2/acs_source/zh2game/player/player.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/player.acs
@@ -10,6 +10,7 @@
 #include "team.acs"
 #include "skin.acs"
 #include "inventory.acs"
+#include "lock.acs"
 #include "name.acs"
 #include "state.acs"
 #include "stats.acs"

--- a/src/ZombieHorde2/acs_source/zh2game/settings/hudactions.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/settings/hudactions.acs
@@ -42,26 +42,13 @@ strict namespace Settings
         ZH2Game::GameContext.HasClientSettingsHudOpen = true;
         ZH2Game::GameContext.HasAdminHudOpen = false; // Also make sure the admin hud is disabled.
         Hud::SetCursorEnabled(true);
-
-        if (!NamedRequestScriptPuke("zh2_internal_menu_clientsettings_request_set_frozen", int(true)))
-            Logger::LogError(LogSource, "Failed to set frozen state on player for settings hud.");
+        Player::LockMovement(true);
     }
 
     internal void CloseClientSettingsMenu()
     {
         ZH2Game::GameContext.HasClientSettingsHudOpen = false;
         Hud::SetCursorEnabled(false);
-
-        if (!NamedRequestScriptPuke("zh2_internal_menu_clientsettings_request_set_frozen", int(false)))
-            Logger::LogError(LogSource, "Failed to unset frozen state on player for settings hud.");
-    }
-
-
-    // Called from the client to set/unset freeze.
-    script "zh2_internal_menu_clientsettings_request_set_frozen" (int set) net
-    {
-        if (set && TrackedProperties::AddProperty((int)TrackedProperties::TRACKED_TOTALLYFROZEN)
-            || !set && TrackedProperties::RemoveProperty((int)TrackedProperties::TRACKED_TOTALLYFROZEN))
-            SetPlayerProperty(0, set, PROP_TOTALLYFROZEN);
+        Player::LockMovement(false);
     }
 }

--- a/src/ZombieHorde2/menudef.debug
+++ b/src/ZombieHorde2/menudef.debug
@@ -18,6 +18,7 @@ OptionMenu "ZH2DebugMenu"
     StaticText " "
     
     StaticText "Debug commands (general)", 1
+    Command "Unlock player", "pukename zh2_action_unlockplayer"
     Command "Give start weapons", "pukename zh2_action_debuggivestartweapons"
     Command "Log requested client settings (clientside)", "pukename zh2_action_debugrequestedclientsettings_clientside"
     


### PR DESCRIPTION
Adds a new system that locks the player's angle and pitch clientside. The player's weapon will also be locked, though this remains a serverside action as the client is not authoritive over this.

This system adds the benefit of being able to lock the player without freezing them. Freezing requires full serverside control, and it can possibly be overwritten. Additionally this new system allows the player to continue moving, which improves the experience a lot.