### PR TITLE
Continuation of 0545 duplicate issue

### DIFF
--- a/src/ZombieHorde2Legacy/textures.drresources
+++ b/src/ZombieHorde2Legacy/textures.drresources
@@ -209,12 +209,12 @@ WallTexture "1171", 128, 128
 // Notice, as `0545` is also defined as a texture, we use the full path here to avoid using that one.
 WallTexture "745", 64, 96
 {
-    Patch "textures/legacy/drresources/0545", 0, 0
+    Patch "0545", 0, 0
 }
 
 WallTexture "746", 32, 96
 {
-    Patch "textures/legacy/drresources/0545", -64, 0
+    Patch "0545", -64, 0
 }
 
 WallTexture "0062", 64, 64


### PR DESCRIPTION
Continuation of #55.
The 745 & 746 textures pointed to a deleted duplicate textures. Now, it will point to the correct textures.