### PR TITLE
Fix VRTEX textures & maps misalignment.

### DIFF
--- a/mapsrc/ZombieHorde2Legacy/ZE11/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZE11/TEXTMAP
@@ -42172,7 +42172,6 @@ sector = 65;
 sidedef // 40
 {
 sector = 68;
-offsetx = 64;
 texturebottom = "VRTEX2";
 }
 
@@ -43274,13 +43273,11 @@ texturebottom = "VRTEX3";
 sidedef // 238
 {
 sector = 42;
-offsetx = 64;
 }
 
 sidedef // 239
 {
 sector = 7;
-offsetx = 64;
 texturebottom = "VRTEX2";
 }
 
@@ -46017,7 +46014,6 @@ texturebottom = "VRTEX2";
 sidedef // 693
 {
 sector = 74;
-offsetx = 64;
 }
 
 sidedef // 694
@@ -46238,13 +46234,11 @@ texturemiddle = "VRTEX4";
 sidedef // 731
 {
 sector = 86;
-offsetx = 64;
 }
 
 sidedef // 732
 {
 sector = 87;
-offsetx = 64;
 texturebottom = "VRTEX2";
 }
 
@@ -46271,7 +46265,6 @@ texturebottom = "VRTEX2";
 sidedef // 736
 {
 sector = 87;
-offsetx = 128;
 }
 
 sidedef // 737
@@ -46586,7 +46579,6 @@ texturemiddle = "VRTEX4";
 sidedef // 785
 {
 sector = 96;
-offsetx = 128;
 texturebottom = "VRTEX2";
 }
 
@@ -46598,7 +46590,6 @@ sector = 93;
 sidedef // 787
 {
 sector = 95;
-offsetx = 128;
 }
 
 sidedef // 788
@@ -46636,7 +46627,6 @@ texturemiddle = "VRTEX4";
 sidedef // 793
 {
 sector = 95;
-offsetx = 128;
 }
 
 sidedef // 794
@@ -46667,7 +46657,6 @@ sector = 93;
 sidedef // 798
 {
 sector = 96;
-offsetx = 128;
 texturebottom = "VRTEX2";
 }
 
@@ -48221,7 +48210,6 @@ sector = 60;
 sidedef // 1044
 {
 sector = 7;
-offsetx = 63;
 texturebottom = "VRTEX2";
 }
 
@@ -49485,7 +49473,6 @@ sector = 99;
 sidedef // 1255
 {
 sector = 101;
-offsetx = 64;
 }
 
 sidedef // 1256
@@ -49509,7 +49496,6 @@ sector = 98;
 sidedef // 1259
 {
 sector = 410;
-offsetx = 128;
 texturebottom = "VRTEX2";
 }
 
@@ -51542,7 +51528,6 @@ offsetx = 200;
 sidedef // 1600
 {
 sector = 410;
-offsetx = 64;
 texturebottom = "VRTEX2";
 }
 
@@ -52489,6 +52474,7 @@ sidedef // 1755
 {
 sector = 249;
 texturebottom = "VRTEX3";
+offsetx_bottom = 58.0;
 }
 
 sidedef // 1756
@@ -52786,7 +52772,6 @@ sector = 247;
 sidedef // 1800
 {
 sector = 248;
-offsetx = 128;
 texturebottom = "VRTEX2";
 }
 
@@ -53349,6 +53334,7 @@ sidedef // 1893
 sector = 249;
 offsetx = 19;
 texturebottom = "VRTEX3";
+offsetx_bottom = 42.0;
 }
 
 sidedef // 1894
@@ -53420,6 +53406,7 @@ sidedef // 1905
 sector = 252;
 offsetx = 210;
 texturebottom = "VRTEX3";
+offsetx_bottom = 40.0;
 }
 
 sidedef // 1906
@@ -53464,6 +53451,7 @@ sidedef // 1913
 {
 sector = 254;
 texturebottom = "VRTEX3";
+offsetx_bottom = 58.0;
 }
 
 sidedef // 1914
@@ -53509,6 +53497,7 @@ sidedef // 1921
 {
 sector = 249;
 texturebottom = "VRTEX3";
+offsetx_bottom = 58.0;
 }
 
 sidedef // 1922
@@ -53522,6 +53511,7 @@ sidedef // 1923
 sector = 253;
 offsetx = 82;
 texturebottom = "VRTEX3";
+offsetx_bottom = 168.0;
 }
 
 sidedef // 1924
@@ -53547,6 +53537,7 @@ sidedef // 1927
 {
 sector = 276;
 texturebottom = "VRTEX3";
+offsetx_bottom = 58.0;
 }
 
 sidedef // 1928
@@ -53570,6 +53561,7 @@ sidedef // 1931
 {
 sector = 249;
 texturebottom = "VRTEX3";
+offsetx_bottom = 58.0;
 }
 
 sidedef // 1932
@@ -53581,6 +53573,7 @@ sidedef // 1933
 {
 sector = 249;
 texturebottom = "VRTEX3";
+offsetx_bottom = 58.0;
 }
 
 sidedef // 1934
@@ -53611,6 +53604,7 @@ sidedef // 1938
 {
 sector = 249;
 texturebottom = "VRTEX3";
+offsetx_bottom = 58.0;
 }
 
 sidedef // 1939
@@ -53639,6 +53633,7 @@ sidedef // 1943
 {
 sector = 249;
 texturebottom = "VRTEX3";
+offsetx_bottom = 58.0;
 }
 
 sidedef // 1944
@@ -55323,7 +55318,6 @@ offsetx = 448;
 sidedef // 2226
 {
 sector = 286;
-offsetx = 64;
 texturebottom = "VRTEX2";
 }
 
@@ -56753,7 +56747,6 @@ sector = 359;
 sidedef // 2462
 {
 sector = 360;
-offsetx = 64;
 texturebottom = "VRTEX2";
 }
 
@@ -57295,14 +57288,12 @@ sector = 329;
 sidedef // 2554
 {
 sector = 423;
-offsetx = 63;
 texturebottom = "VRTEX2";
 }
 
 sidedef // 2555
 {
 sector = 329;
-offsetx = 128;
 }
 
 sidedef // 2556
@@ -57569,7 +57560,6 @@ texturebottom = "VRTEX2";
 sidedef // 2600
 {
 sector = 329;
-offsetx = 64;
 }
 
 sidedef // 2601
@@ -57783,7 +57773,6 @@ texturebottom = "VRTEX2";
 sidedef // 2638
 {
 sector = 329;
-offsetx = 64;
 }
 
 sidedef // 2639
@@ -59110,7 +59099,6 @@ texturebottom = "VRTEX2";
 sidedef // 2852
 {
 sector = 138;
-offsetx = 128;
 }
 
 sidedef // 2853
@@ -59285,7 +59273,6 @@ texturebottom = "VRTEX2";
 sidedef // 2880
 {
 sector = 136;
-offsetx = 128;
 }
 
 sidedef // 2881
@@ -60406,6 +60393,7 @@ sidedef // 3055
 sector = 276;
 offsetx = 146;
 texturebottom = "VRTEX3";
+offsetx_bottom = 104.0;
 }
 
 sidedef // 3056
@@ -60437,7 +60425,6 @@ offsetx = 896;
 sidedef // 3060
 {
 sector = 420;
-offsetx = 63;
 texturebottom = "VRTEX2";
 }
 
@@ -60498,14 +60485,12 @@ texturemiddle = "VRTEX4";
 sidedef // 3070
 {
 sector = 423;
-offsetx = 56;
 texturebottom = "VRTEX2";
 }
 
 sidedef // 3071
 {
 sector = 329;
-offsetx = 64;
 }
 
 sidedef // 3072
@@ -60539,7 +60524,6 @@ sector = 329;
 sidedef // 3077
 {
 sector = 423;
-offsetx = 64;
 texturebottom = "VRTEX2";
 }
 
@@ -60716,6 +60700,7 @@ sidedef // 3106
 {
 sector = 249;
 texturebottom = "VRTEX3";
+offsetx_bottom = -125.0;
 }
 
 sidedef // 3107
@@ -60949,18 +60934,17 @@ sidedef // 3144
 sector = 249;
 offsetx = 321;
 texturebottom = "VRTEX3";
+offsetx_bottom = -65.0;
 }
 
 sidedef // 3145
 {
 sector = 433;
-offsetx = 4;
 }
 
 sidedef // 3146
 {
 sector = 434;
-offsetx = 256;
 texturebottom = "VRTEX2";
 }
 
@@ -60999,12 +60983,14 @@ sidedef // 3152
 sector = 433;
 offsetx = 256;
 texturebottom = "VRTEX3";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 3153
 {
 sector = 249;
 texturebottom = "VRTEX3";
+offsetx_bottom = 61.0;
 }
 
 sidedef // 3154
@@ -61021,12 +61007,14 @@ sidedef // 3156
 {
 sector = 249;
 texturebottom = "VRTEX3";
+offsetx_bottom = -125.0;
 }
 
 sidedef // 3157
 {
 sector = 249;
 texturebottom = "VRTEX3";
+offsetx_bottom = -131.0;
 }
 
 sidedef // 3158
@@ -61038,6 +61026,7 @@ sidedef // 3159
 {
 sector = 249;
 texturebottom = "VRTEX3";
+offsetx_bottom = 61.0;
 }
 
 sidedef // 3160
@@ -61048,14 +61037,12 @@ sector = 428;
 sidedef // 3161
 {
 sector = 249;
-offsetx = 4;
 texturebottom = "VRTEX2";
 }
 
 sidedef // 3162
 {
 sector = 430;
-offsetx = 256;
 }
 
 sidedef // 3163
@@ -61075,6 +61062,7 @@ sidedef // 3165
 {
 sector = 249;
 texturebottom = "VRTEX3";
+offsetx_bottom = -128.0;
 }
 
 sidedef // 3166
@@ -61121,6 +61109,7 @@ sidedef // 3173
 sector = 249;
 offsetx = 128;
 texturebottom = "VRTEX3";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 3174
@@ -61140,12 +61129,14 @@ sidedef // 3176
 sector = 430;
 offsetx = 4;
 texturebottom = "VRTEX3";
+offsetx_bottom = -129.0;
 }
 
 sidedef // 3177
 {
 sector = 249;
 texturebottom = "VRTEX3";
+offsetx_bottom = -128.0;
 }
 
 sidedef // 3178
@@ -61164,12 +61155,14 @@ sidedef // 3180
 sector = 249;
 offsetx = 192;
 texturebottom = "VRTEX3";
+offsetx_bottom = -128.0;
 }
 
 sidedef // 3181
 {
 sector = 249;
 texturebottom = "VRTEX3";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 3182
@@ -61180,26 +61173,22 @@ sector = 433;
 sidedef // 3183
 {
 sector = 249;
-offsetx = 64;
 texturebottom = "VRTEX2";
 }
 
 sidedef // 3184
 {
 sector = 434;
-offsetx = 192;
 }
 
 sidedef // 3185
 {
 sector = 435;
-offsetx = 128;
 }
 
 sidedef // 3186
 {
 sector = 434;
-offsetx = 128;
 texturebottom = "VRTEX2";
 }
 
@@ -61214,6 +61203,7 @@ sidedef // 3188
 sector = 435;
 offsetx = 4;
 texturebottom = "VRTEX3";
+offsetx_bottom = -129.0;
 }
 
 sidedef // 3189

--- a/mapsrc/ZombieHorde2Legacy/ZM07/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM07/TEXTMAP
@@ -30478,12 +30478,14 @@ sidedef // 0
 {
 sector = 0;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1
 {
 sector = 0;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2
@@ -30491,6 +30493,7 @@ sidedef // 2
 sector = 0;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 3
@@ -30514,12 +30517,14 @@ sidedef // 6
 {
 sector = 1;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 7
 {
 sector = 1;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 8
@@ -30530,7 +30535,6 @@ sector = 1;
 sidedef // 9
 {
 sector = 0;
-offsetx = 128;
 texturebottom = "VRTEX2";
 }
 
@@ -30578,6 +30582,7 @@ sidedef // 16
 {
 sector = 0;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 17
@@ -30589,18 +30594,21 @@ sidedef // 18
 {
 sector = 3;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 19
 {
 sector = 3;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 20
 {
 sector = 4;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 21
@@ -30612,36 +30620,42 @@ sidedef // 22
 {
 sector = 3;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 23
 {
 sector = 3;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 24
 {
 sector = 0;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 25
 {
 sector = 4;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 26
 {
 sector = 4;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 27
 {
 sector = 4;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 28
@@ -30649,6 +30663,7 @@ sidedef // 28
 sector = 4;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 29
@@ -30656,6 +30671,7 @@ sidedef // 29
 sector = 4;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 30
@@ -30739,6 +30755,7 @@ sidedef // 44
 {
 sector = 134;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 45
@@ -30746,6 +30763,7 @@ sidedef // 45
 sector = 7;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 46
@@ -30753,6 +30771,7 @@ sidedef // 46
 sector = 7;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 47
@@ -30761,6 +30780,8 @@ sector = 134;
 offsetx = 64;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = -64.0;
+offsetx_bottom = -64.0;
 }
 
 sidedef // 48
@@ -30773,6 +30794,7 @@ sidedef // 49
 sector = 7;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 50
@@ -30790,6 +30812,7 @@ sidedef // 52
 {
 sector = 6;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 53
@@ -30818,12 +30841,14 @@ sidedef // 57
 {
 sector = 8;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 58
 {
 sector = 8;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 59
@@ -30877,12 +30902,14 @@ sidedef // 67
 sector = 9;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 68
 {
 sector = 10;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 69
@@ -30890,6 +30917,7 @@ sidedef // 69
 sector = 9;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 70
@@ -30955,6 +30983,7 @@ sidedef // 80
 {
 sector = 10;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 81
@@ -30962,6 +30991,7 @@ sidedef // 81
 sector = 10;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 82
@@ -30979,12 +31009,14 @@ sidedef // 84
 {
 sector = 12;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 85
 {
 sector = 11;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 86
@@ -30992,12 +31024,14 @@ sidedef // 86
 sector = 11;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 87
 {
 sector = 11;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 88
@@ -31005,6 +31039,7 @@ sidedef // 88
 sector = 4;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 89
@@ -31023,6 +31058,7 @@ sidedef // 91
 sector = 12;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 92
@@ -31031,6 +31067,7 @@ sector = 4;
 offsetx = 64;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX3";
+offsetx_top = -64.0;
 }
 
 sidedef // 93
@@ -31048,18 +31085,21 @@ sidedef // 95
 {
 sector = 14;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 96
 {
 sector = 23;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 97
 {
 sector = 23;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 98
@@ -31067,6 +31107,7 @@ sidedef // 98
 sector = 14;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 99
@@ -31074,6 +31115,7 @@ sidedef // 99
 sector = 4;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 100
@@ -31085,6 +31127,7 @@ sidedef // 101
 {
 sector = 15;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 102
@@ -31092,6 +31135,7 @@ sidedef // 102
 sector = 14;
 offsetx = 32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 103
@@ -31099,6 +31143,7 @@ sidedef // 103
 sector = 15;
 offsetx = 96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 104
@@ -31110,18 +31155,21 @@ sidedef // 105
 {
 sector = 16;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 106
 {
 sector = 15;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 107
 {
 sector = 16;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 108
@@ -31129,6 +31177,7 @@ sidedef // 108
 sector = 17;
 offsetx = 32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 109
@@ -31140,6 +31189,7 @@ sidedef // 110
 {
 sector = 17;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 111
@@ -31147,6 +31197,7 @@ sidedef // 111
 sector = 16;
 offsetx = 96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 112
@@ -31158,6 +31209,7 @@ sidedef // 113
 {
 sector = 18;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 114
@@ -31165,6 +31217,7 @@ sidedef // 114
 sector = 17;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 115
@@ -31172,6 +31225,7 @@ sidedef // 115
 sector = 18;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 116
@@ -31183,6 +31237,7 @@ sidedef // 117
 {
 sector = 19;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 118
@@ -31190,6 +31245,7 @@ sidedef // 118
 sector = 18;
 offsetx = 32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 119
@@ -31197,6 +31253,7 @@ sidedef // 119
 sector = 19;
 offsetx = 96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 120
@@ -31208,24 +31265,28 @@ sidedef // 121
 {
 sector = 22;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 122
 {
 sector = 19;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 123
 {
 sector = 22;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 124
 {
 sector = 23;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 125
@@ -31233,12 +31294,14 @@ sidedef // 125
 sector = 23;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 126
 {
 sector = 23;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 127
@@ -31246,6 +31309,7 @@ sidedef // 127
 sector = 23;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 128
@@ -31253,12 +31317,14 @@ sidedef // 128
 sector = 31;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 129
 {
 sector = 31;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 130
@@ -31266,18 +31332,21 @@ sidedef // 130
 sector = 24;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 131
 {
 sector = 20;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 132
 {
 sector = 20;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 133
@@ -31285,6 +31354,7 @@ sidedef // 133
 sector = 13;
 offsetx = 64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 134
@@ -31297,18 +31367,21 @@ sidedef // 135
 sector = 20;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 136
 {
 sector = 20;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 137
 {
 sector = 23;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 138
@@ -31321,12 +31394,14 @@ sidedef // 139
 sector = 23;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 140
 {
 sector = 13;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 141
@@ -31345,6 +31420,7 @@ sidedef // 143
 {
 sector = 21;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 144
@@ -31363,6 +31439,7 @@ sidedef // 146
 {
 sector = 21;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 147
@@ -31370,6 +31447,7 @@ sidedef // 147
 sector = 24;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 148
@@ -31381,6 +31459,7 @@ sidedef // 149
 {
 sector = 23;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 150
@@ -31388,6 +31467,7 @@ sidedef // 150
 sector = 23;
 offsetx = 32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 151
@@ -31395,6 +31475,7 @@ sidedef // 151
 sector = 22;
 offsetx = 96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 152
@@ -31414,12 +31495,14 @@ sidedef // 154
 sector = 24;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 155
 {
 sector = 23;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 156
@@ -31430,7 +31513,6 @@ sector = 24;
 sidedef // 157
 {
 sector = 13;
-offsetx = 128;
 texturebottom = "VRTEX2";
 }
 
@@ -31439,18 +31521,19 @@ sidedef // 158
 sector = 24;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 159
 {
 sector = 13;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 160
 {
 sector = 21;
-offsetx = 128;
 }
 
 sidedef // 161
@@ -31462,7 +31545,6 @@ texturebottom = "VRTEX2";
 sidedef // 162
 {
 sector = 23;
-offsetx = 128;
 texturebottom = "VRTEX2";
 }
 
@@ -31474,7 +31556,6 @@ sector = 24;
 sidedef // 164
 {
 sector = 21;
-offsetx = 128;
 }
 
 sidedef // 165
@@ -31500,6 +31581,7 @@ sidedef // 168
 sector = 4;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 169
@@ -31507,6 +31589,7 @@ sidedef // 169
 sector = 29;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 170
@@ -31514,6 +31597,7 @@ sidedef // 170
 sector = 13;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 171
@@ -31526,6 +31610,7 @@ sidedef // 172
 sector = 29;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 173
@@ -31533,12 +31618,14 @@ sidedef // 173
 sector = 29;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 174
 {
 sector = 13;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 175
@@ -31546,12 +31633,14 @@ sidedef // 175
 sector = 4;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 176
 {
 sector = 4;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 177
@@ -31564,6 +31653,7 @@ sidedef // 178
 sector = 25;
 offsetx = 96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 179
@@ -31575,12 +31665,14 @@ sidedef // 180
 {
 sector = 25;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 181
 {
 sector = 25;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 182
@@ -31588,18 +31680,21 @@ sidedef // 182
 sector = 26;
 offsetx = 32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 183
 {
 sector = 4;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 184
 {
 sector = 26;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 185
@@ -31612,6 +31707,7 @@ sidedef // 186
 sector = 26;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 187
@@ -31619,12 +31715,14 @@ sidedef // 187
 sector = 27;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 188
 {
 sector = 27;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 189
@@ -31637,6 +31735,7 @@ sidedef // 190
 sector = 27;
 offsetx = 96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 191
@@ -31644,12 +31743,14 @@ sidedef // 191
 sector = 28;
 offsetx = 96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 192
 {
 sector = 28;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 193
@@ -31662,12 +31763,14 @@ sidedef // 194
 sector = 28;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 195
 {
 sector = 29;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 196
@@ -31687,6 +31790,7 @@ sidedef // 198
 {
 sector = 30;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 199
@@ -31705,12 +31809,14 @@ sidedef // 201
 {
 sector = 30;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 202
 {
 sector = 13;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 203
@@ -31718,6 +31824,7 @@ sidedef // 203
 sector = 31;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 204
@@ -31736,6 +31843,7 @@ sidedef // 206
 sector = 32;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 207
@@ -31777,6 +31885,7 @@ sidedef // 213
 sector = 33;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 214
@@ -31788,7 +31897,6 @@ texturebottom = "VRTEX2";
 sidedef // 215
 {
 sector = 30;
-offsetx = 128;
 }
 
 sidedef // 216
@@ -31817,13 +31925,11 @@ texturebottom = "VRTEX3";
 sidedef // 220
 {
 sector = 31;
-offsetx = 64;
 }
 
 sidedef // 221
 {
 sector = 30;
-offsetx = 64;
 texturebottom = "VRTEX2";
 }
 
@@ -31831,6 +31937,7 @@ sidedef // 222
 {
 sector = 23;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 223
@@ -31838,18 +31945,21 @@ sidedef // 223
 sector = 35;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 224
 {
 sector = 23;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 225
 {
 sector = 34;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 226
@@ -31857,12 +31967,14 @@ sidedef // 226
 sector = 23;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 227
 {
 sector = 36;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 228
@@ -31870,6 +31982,7 @@ sidedef // 228
 sector = 35;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 229
@@ -31888,12 +32001,14 @@ sidedef // 231
 sector = 37;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 232
 {
 sector = 36;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 233
@@ -31923,6 +32038,7 @@ sidedef // 237
 sector = 37;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 238
@@ -31940,12 +32056,14 @@ sidedef // 240
 {
 sector = 34;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 241
 {
 sector = 133;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 242
@@ -31959,6 +32077,8 @@ sector = 23;
 offsetx = 64;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = -64.0;
+offsetx_bottom = -64.0;
 }
 
 sidedef // 244
@@ -31970,6 +32090,7 @@ sidedef // 245
 {
 sector = 38;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 246
@@ -31977,6 +32098,7 @@ sidedef // 246
 sector = 43;
 offsetx = 96;
 texturetop = "VRTEX4";
+offsetx_top = -32.0;
 }
 
 sidedef // 247
@@ -31984,6 +32106,7 @@ sidedef // 247
 sector = 38;
 offsetx = 96;
 texturebottom = "VRTEX4";
+offsetx_bottom = -32.0;
 }
 
 sidedef // 248
@@ -31991,12 +32114,14 @@ sidedef // 248
 sector = 38;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 249
 {
 sector = 23;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 250
@@ -32004,6 +32129,7 @@ sidedef // 250
 sector = 39;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 251
@@ -32015,12 +32141,14 @@ sidedef // 252
 {
 sector = 42;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 253
 {
 sector = 39;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 254
@@ -32028,6 +32156,7 @@ sidedef // 254
 sector = 13;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 255
@@ -32039,6 +32168,7 @@ sidedef // 256
 {
 sector = 13;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 257
@@ -32046,6 +32176,7 @@ sidedef // 257
 sector = 40;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 258
@@ -32057,6 +32188,7 @@ sidedef // 259
 {
 sector = 40;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 260
@@ -32064,6 +32196,7 @@ sidedef // 260
 sector = 40;
 offsetx = 96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 261
@@ -32071,6 +32204,7 @@ sidedef // 261
 sector = 41;
 offsetx = 96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 262
@@ -32083,6 +32217,7 @@ sidedef // 263
 sector = 41;
 offsetx = 32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
 }
 
 sidedef // 264
@@ -32090,6 +32225,7 @@ sidedef // 264
 sector = 41;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 265
@@ -32097,12 +32233,14 @@ sidedef // 265
 sector = 43;
 offsetx = 96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 266
 {
 sector = 42;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 267
@@ -32110,6 +32248,7 @@ sidedef // 267
 sector = 42;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 268
@@ -32117,12 +32256,14 @@ sidedef // 268
 sector = 38;
 offsetx = 32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 269
 {
 sector = 43;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 270
@@ -32134,6 +32275,7 @@ sidedef // 271
 {
 sector = 43;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 272
@@ -32141,18 +32283,21 @@ sidedef // 272
 sector = 38;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 273
 {
 sector = 38;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 274
 {
 sector = 38;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 275
@@ -32160,12 +32305,14 @@ sidedef // 275
 sector = 38;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 276
 {
 sector = 44;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 277
@@ -32173,6 +32320,7 @@ sidedef // 277
 sector = 44;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 278
@@ -32180,6 +32328,7 @@ sidedef // 278
 sector = 44;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 279
@@ -32188,6 +32337,8 @@ sector = 23;
 offsetx = 64;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = -64.0;
+offsetx_bottom = -64.0;
 }
 
 sidedef // 280
@@ -32200,24 +32351,28 @@ sidedef // 281
 sector = 44;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 282
 {
 sector = 44;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 283
 {
 sector = 44;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 284
 {
 sector = 38;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 285
@@ -32229,12 +32384,14 @@ sidedef // 286
 {
 sector = 23;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 287
 {
 sector = 38;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 288
@@ -32242,12 +32399,14 @@ sidedef // 288
 sector = 45;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 289
 {
 sector = 45;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 290
@@ -32256,6 +32415,8 @@ sector = 23;
 offsetx = 64;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = -64.0;
+offsetx_bottom = -64.0;
 }
 
 sidedef // 291
@@ -32268,12 +32429,14 @@ sidedef // 292
 sector = 45;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 293
 {
 sector = 45;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 294
@@ -32281,6 +32444,7 @@ sidedef // 294
 sector = 38;
 offsetx = 64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 295
@@ -32294,6 +32458,7 @@ sidedef // 296
 {
 sector = 23;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 297
@@ -32476,24 +32641,28 @@ sidedef // 329
 {
 sector = 51;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 330
 {
 sector = 50;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 331
 {
 sector = 50;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 332
 {
 sector = 50;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 333
@@ -32512,6 +32681,7 @@ sidedef // 335
 sector = 51;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 336
@@ -32520,6 +32690,7 @@ sector = 4;
 offsetx = 64;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX3";
+offsetx_top = -64.0;
 }
 
 sidedef // 337
@@ -32532,18 +32703,21 @@ sidedef // 338
 sector = 4;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 339
 {
 sector = 52;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 340
 {
 sector = 11;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 341
@@ -32556,6 +32730,7 @@ sidedef // 342
 sector = 52;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 343
@@ -32563,6 +32738,7 @@ sidedef // 343
 sector = 50;
 offsetx = 64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 344
@@ -32574,6 +32750,7 @@ sidedef // 345
 {
 sector = 54;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 346
@@ -32581,6 +32758,7 @@ sidedef // 346
 sector = 54;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 347
@@ -32588,6 +32766,7 @@ sidedef // 347
 sector = 54;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 348
@@ -32604,12 +32783,14 @@ sidedef // 350
 {
 sector = 53;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 351
 {
 sector = 23;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 352
@@ -32626,6 +32807,7 @@ sidedef // 354
 {
 sector = 53;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 355
@@ -32633,6 +32815,7 @@ sidedef // 355
 sector = 55;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 356
@@ -32649,6 +32832,7 @@ sidedef // 358
 {
 sector = 55;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 359
@@ -32656,6 +32840,7 @@ sidedef // 359
 sector = 23;
 offsetx = 64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 360
@@ -32679,6 +32864,7 @@ sidedef // 363
 sector = 56;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 364
@@ -32707,6 +32893,7 @@ sidedef // 368
 {
 sector = 54;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 369
@@ -32725,6 +32912,7 @@ sidedef // 371
 sector = 57;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 372
@@ -32753,6 +32941,7 @@ sidedef // 376
 {
 sector = 54;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 377
@@ -32771,6 +32960,7 @@ sidedef // 379
 sector = 58;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 380
@@ -32800,6 +32990,7 @@ sidedef // 384
 sector = 54;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 385
@@ -32807,18 +32998,21 @@ sidedef // 385
 sector = 60;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 386
 {
 sector = 60;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 387
 {
 sector = 59;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 388
@@ -32826,6 +33020,7 @@ sidedef // 388
 sector = 23;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX3";
+offsetx_top = 0.0;
 }
 
 sidedef // 389
@@ -32839,12 +33034,14 @@ sidedef // 390
 sector = 23;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 391
 {
 sector = 60;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 392
@@ -32852,12 +33049,14 @@ sidedef // 392
 sector = 59;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 393
 {
 sector = 23;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 394
@@ -32865,6 +33064,7 @@ sidedef // 394
 sector = 60;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 395
@@ -32872,6 +33072,7 @@ sidedef // 395
 sector = 23;
 offsetx = 64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 396
@@ -32895,12 +33096,14 @@ sidedef // 399
 sector = 60;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 400
 {
 sector = 61;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 401
@@ -32908,6 +33111,7 @@ sidedef // 401
 sector = 61;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 402
@@ -32915,12 +33119,14 @@ sidedef // 402
 sector = 61;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 403
 {
 sector = 61;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 404
@@ -32928,12 +33134,14 @@ sidedef // 404
 sector = 61;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 405
 {
 sector = 60;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 406
@@ -32946,6 +33154,7 @@ sidedef // 407
 sector = 60;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 408
@@ -32953,12 +33162,14 @@ sidedef // 408
 sector = 62;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 409
 {
 sector = 62;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 410
@@ -32966,12 +33177,14 @@ sidedef // 410
 sector = 62;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 411
 {
 sector = 62;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 412
@@ -32979,6 +33192,7 @@ sidedef // 412
 sector = 62;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 413
@@ -33059,18 +33273,21 @@ sidedef // 425
 {
 sector = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 426
 {
 sector = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 427
 {
 sector = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 428
@@ -33078,12 +33295,14 @@ sidedef // 428
 sector = 64;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 429
 {
 sector = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 430
@@ -33091,6 +33310,7 @@ sidedef // 430
 sector = 64;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 431
@@ -33098,12 +33318,14 @@ sidedef // 431
 sector = 64;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 432
 {
 sector = 62;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 433
@@ -33115,6 +33337,7 @@ sidedef // 434
 {
 sector = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 435
@@ -33122,6 +33345,7 @@ sidedef // 435
 sector = 64;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 436
@@ -33129,12 +33353,14 @@ sidedef // 436
 sector = 64;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 437
 {
 sector = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 438
@@ -33142,24 +33368,28 @@ sidedef // 438
 sector = 64;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 439
 {
 sector = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 440
 {
 sector = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 441
 {
 sector = 62;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 442
@@ -33172,6 +33402,7 @@ sidedef // 443
 sector = 62;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 444
@@ -33179,6 +33410,7 @@ sidedef // 444
 sector = 62;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 445
@@ -33186,6 +33418,7 @@ sidedef // 445
 sector = 64;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 446
@@ -33193,6 +33426,7 @@ sidedef // 446
 sector = 62;
 offsetx = 64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 447
@@ -33205,18 +33439,21 @@ sidedef // 448
 sector = 64;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 449
 {
 sector = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 450
 {
 sector = 62;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 451
@@ -33236,6 +33473,7 @@ sidedef // 453
 sector = 60;
 offsetx = 32;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 454
@@ -33243,6 +33481,7 @@ sidedef // 454
 sector = 60;
 offsetx = 96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 455
@@ -33250,6 +33489,7 @@ sidedef // 455
 sector = 65;
 offsetx = 24;
 texturemiddle = "VRTEX4";
+offsetx_mid = 24.0;
 }
 
 sidedef // 456
@@ -33258,6 +33498,8 @@ sector = 60;
 offsetx = 24;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = 24.0;
+offsetx_bottom = 24.0;
 }
 
 sidedef // 457
@@ -33270,6 +33512,7 @@ sidedef // 458
 sector = 65;
 offsetx = 32;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 459
@@ -33285,12 +33528,14 @@ sidedef // 460
 sector = 60;
 offsetx = 40;
 texturemiddle = "VRTEX4";
+offsetx_mid = 40.0;
 }
 
 sidedef // 461
 {
 sector = 67;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 462
@@ -33302,12 +33547,14 @@ sidedef // 463
 {
 sector = 66;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 464
 {
 sector = 67;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 465
@@ -33315,30 +33562,35 @@ sidedef // 465
 sector = 66;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 466
 {
 sector = 66;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 467
 {
 sector = 78;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 468
 {
 sector = 78;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 469
 {
 sector = 66;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 470
@@ -33350,6 +33602,7 @@ sidedef // 471
 {
 sector = 54;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 472
@@ -33357,6 +33610,7 @@ sidedef // 472
 sector = 69;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 473
@@ -33364,12 +33618,14 @@ sidedef // 473
 sector = 70;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 474
 {
 sector = 68;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 475
@@ -33377,6 +33633,8 @@ sidedef // 475
 sector = 23;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = 0.0;
+offsetx_bottom = 0.0;
 }
 
 sidedef // 476
@@ -33389,6 +33647,7 @@ sidedef // 477
 sector = 68;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 478
@@ -33396,18 +33655,21 @@ sidedef // 478
 sector = 69;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 479
 {
 sector = 69;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 480
 {
 sector = 60;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 481
@@ -33420,6 +33682,7 @@ sidedef // 482
 sector = 23;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 483
@@ -33427,6 +33690,7 @@ sidedef // 483
 sector = 60;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 484
@@ -33443,6 +33707,7 @@ sidedef // 486
 {
 sector = 70;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 487
@@ -33459,12 +33724,14 @@ sidedef // 489
 {
 sector = 68;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 490
 {
 sector = 66;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 491
@@ -33476,6 +33743,7 @@ sidedef // 492
 {
 sector = 66;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 493
@@ -33488,12 +33756,14 @@ sidedef // 494
 sector = 66;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 495
 {
 sector = 71;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 496
@@ -33501,6 +33771,7 @@ sidedef // 496
 sector = 66;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 497
@@ -33518,6 +33789,7 @@ sidedef // 499
 {
 sector = 66;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 500
@@ -33529,6 +33801,7 @@ sidedef // 501
 {
 sector = 71;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 502
@@ -33536,6 +33809,7 @@ sidedef // 502
 sector = 72;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = 96.0;
 }
 
 sidedef // 503
@@ -33547,12 +33821,14 @@ sidedef // 504
 {
 sector = 66;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 505
 {
 sector = 72;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 506
@@ -33564,6 +33840,7 @@ sidedef // 507
 {
 sector = 73;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 508
@@ -33575,12 +33852,14 @@ sidedef // 509
 {
 sector = 66;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 510
 {
 sector = 73;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 511
@@ -33593,6 +33872,7 @@ sidedef // 512
 sector = 74;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 513
@@ -33604,12 +33884,14 @@ sidedef // 514
 {
 sector = 66;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 515
 {
 sector = 74;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 516
@@ -33622,6 +33904,7 @@ sidedef // 517
 sector = 75;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 518
@@ -33633,12 +33916,14 @@ sidedef // 519
 {
 sector = 66;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 520
 {
 sector = 75;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 521
@@ -33651,6 +33936,7 @@ sidedef // 522
 sector = 76;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = 96.0;
 }
 
 sidedef // 523
@@ -33662,12 +33948,14 @@ sidedef // 524
 {
 sector = 102;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 525
 {
 sector = 76;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 526
@@ -33679,18 +33967,21 @@ sidedef // 527
 {
 sector = 77;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 528
 {
 sector = 78;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 529
 {
 sector = 77;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 530
@@ -33707,12 +33998,14 @@ sidedef // 532
 {
 sector = 102;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 533
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 534
@@ -33724,6 +34017,7 @@ sidedef // 535
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 536
@@ -33741,6 +34035,7 @@ sidedef // 538
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 539
@@ -33752,6 +34047,7 @@ sidedef // 540
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 541
@@ -33763,6 +34059,7 @@ sidedef // 542
 {
 sector = 79;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 543
@@ -33775,6 +34072,7 @@ sidedef // 544
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 545
@@ -33786,12 +34084,14 @@ sidedef // 546
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 547
 {
 sector = 80;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 548
@@ -33809,6 +34109,7 @@ sidedef // 550
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 551
@@ -33820,12 +34121,14 @@ sidedef // 552
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 553
 {
 sector = 81;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 554
@@ -33843,6 +34146,7 @@ sidedef // 556
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 557
@@ -33854,12 +34158,14 @@ sidedef // 558
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 559
 {
 sector = 82;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 560
@@ -33877,6 +34183,7 @@ sidedef // 562
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 563
@@ -33888,12 +34195,14 @@ sidedef // 564
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 565
 {
 sector = 83;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 566
@@ -33911,6 +34220,7 @@ sidedef // 568
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 569
@@ -33922,12 +34232,14 @@ sidedef // 570
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 571
 {
 sector = 84;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 572
@@ -33945,12 +34257,14 @@ sidedef // 574
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 575
 {
 sector = 85;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 576
@@ -33962,12 +34276,14 @@ sidedef // 577
 {
 sector = 78;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 578
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 579
@@ -33979,6 +34295,7 @@ sidedef // 580
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 581
@@ -33996,6 +34313,7 @@ sidedef // 583
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 584
@@ -34007,6 +34325,7 @@ sidedef // 585
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 586
@@ -34018,6 +34337,7 @@ sidedef // 587
 {
 sector = 86;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 588
@@ -34030,6 +34350,7 @@ sidedef // 589
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 590
@@ -34041,12 +34362,14 @@ sidedef // 591
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 592
 {
 sector = 87;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 593
@@ -34064,6 +34387,7 @@ sidedef // 595
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 596
@@ -34075,12 +34399,14 @@ sidedef // 597
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 598
 {
 sector = 88;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 599
@@ -34098,6 +34424,7 @@ sidedef // 601
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 602
@@ -34109,12 +34436,14 @@ sidedef // 603
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 604
 {
 sector = 89;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 605
@@ -34132,6 +34461,7 @@ sidedef // 607
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 608
@@ -34143,12 +34473,14 @@ sidedef // 609
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 610
 {
 sector = 90;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 611
@@ -34166,6 +34498,7 @@ sidedef // 613
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 614
@@ -34177,12 +34510,14 @@ sidedef // 615
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 616
 {
 sector = 91;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 617
@@ -34200,6 +34535,7 @@ sidedef // 619
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 620
@@ -34207,18 +34543,21 @@ sidedef // 620
 sector = 66;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 621
 {
 sector = 78;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 622
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 623
@@ -34230,6 +34569,7 @@ sidedef // 624
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 625
@@ -34247,6 +34587,7 @@ sidedef // 627
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 628
@@ -34258,6 +34599,7 @@ sidedef // 629
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 630
@@ -34269,6 +34611,7 @@ sidedef // 631
 {
 sector = 93;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 632
@@ -34281,6 +34624,7 @@ sidedef // 633
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 634
@@ -34292,12 +34636,14 @@ sidedef // 635
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 636
 {
 sector = 94;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 637
@@ -34315,6 +34661,7 @@ sidedef // 639
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 640
@@ -34326,12 +34673,14 @@ sidedef // 641
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 642
 {
 sector = 95;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 643
@@ -34349,6 +34698,7 @@ sidedef // 645
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 646
@@ -34360,12 +34710,14 @@ sidedef // 647
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 648
 {
 sector = 96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 649
@@ -34383,6 +34735,7 @@ sidedef // 651
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 652
@@ -34394,12 +34747,14 @@ sidedef // 653
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 654
 {
 sector = 97;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 655
@@ -34417,6 +34772,7 @@ sidedef // 657
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 658
@@ -34428,12 +34784,14 @@ sidedef // 659
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 660
 {
 sector = 98;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 661
@@ -34451,6 +34809,7 @@ sidedef // 663
 {
 sector = 78;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 664
@@ -34469,6 +34828,7 @@ sidedef // 666
 {
 sector = 78;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 667
@@ -34480,13 +34840,13 @@ texturebottom = "VRTEX2";
 sidedef // 668
 {
 sector = 100;
-offsetx = 128;
 }
 
 sidedef // 669
 {
 sector = 100;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 670
@@ -34494,6 +34854,7 @@ sidedef // 670
 sector = 100;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 671
@@ -34528,6 +34889,7 @@ sidedef // 676
 {
 sector = 101;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 677
@@ -34535,12 +34897,14 @@ sidedef // 677
 sector = 101;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 678
 {
 sector = 101;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 679
@@ -34548,6 +34912,7 @@ sidedef // 679
 sector = 66;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 680
@@ -34560,12 +34925,14 @@ sidedef // 681
 sector = 101;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 682
 {
 sector = 101;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 683
@@ -34573,12 +34940,14 @@ sidedef // 683
 sector = 101;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 684
 {
 sector = 92;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 685
@@ -34596,13 +34965,13 @@ texturebottom = "VRTEX2";
 sidedef // 687
 {
 sector = 102;
-offsetx = 128;
 }
 
 sidedef // 688
 {
 sector = 102;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 689
@@ -34639,6 +35008,7 @@ sidedef // 694
 {
 sector = 103;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 695
@@ -34646,6 +35016,7 @@ sidedef // 695
 sector = 103;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = 96.0;
 }
 
 sidedef // 696
@@ -34653,6 +35024,7 @@ sidedef // 696
 sector = 111;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 697
@@ -34660,6 +35032,7 @@ sidedef // 697
 sector = 103;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 698
@@ -34672,6 +35045,7 @@ sidedef // 699
 sector = 104;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 700
@@ -34679,6 +35053,7 @@ sidedef // 700
 sector = 104;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 701
@@ -34686,6 +35061,7 @@ sidedef // 701
 sector = 105;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 702
@@ -34698,6 +35074,7 @@ sidedef // 703
 sector = 104;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 704
@@ -34705,6 +35082,7 @@ sidedef // 704
 sector = 105;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 705
@@ -34712,6 +35090,7 @@ sidedef // 705
 sector = 106;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 706
@@ -34719,6 +35098,7 @@ sidedef // 706
 sector = 105;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 707
@@ -34731,6 +35111,7 @@ sidedef // 708
 sector = 106;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 709
@@ -34738,12 +35119,14 @@ sidedef // 709
 sector = 107;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 710
 {
 sector = 106;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 711
@@ -34755,12 +35138,14 @@ sidedef // 712
 {
 sector = 107;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 713
 {
 sector = 108;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 714
@@ -34768,6 +35153,7 @@ sidedef // 714
 sector = 107;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
 }
 
 sidedef // 715
@@ -34780,6 +35166,7 @@ sidedef // 716
 sector = 108;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 717
@@ -34787,6 +35174,7 @@ sidedef // 717
 sector = 109;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = 96.0;
 }
 
 sidedef // 718
@@ -34794,6 +35182,7 @@ sidedef // 718
 sector = 108;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 719
@@ -34806,6 +35195,7 @@ sidedef // 720
 sector = 109;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 721
@@ -34813,6 +35203,7 @@ sidedef // 721
 sector = 110;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 722
@@ -34831,12 +35222,14 @@ sidedef // 724
 sector = 110;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 725
 {
 sector = 101;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 726
@@ -34848,12 +35241,14 @@ sidedef // 727
 {
 sector = 111;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 728
 {
 sector = 111;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 729
@@ -34861,6 +35256,7 @@ sidedef // 729
 sector = 111;
 offsetx = -64;
 texturetop = "VRTEX4";
+offsetx_top = 64.0;
 }
 
 sidedef // 730
@@ -34872,6 +35268,7 @@ sidedef // 731
 {
 sector = 111;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 732
@@ -34889,6 +35286,7 @@ sidedef // 734
 {
 sector = 112;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 735
@@ -34896,6 +35294,7 @@ sidedef // 735
 sector = 120;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 736
@@ -34903,18 +35302,21 @@ sidedef // 736
 sector = 112;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 737
 {
 sector = 0;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 738
 {
 sector = 113;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 739
@@ -34926,6 +35328,7 @@ sidedef // 740
 {
 sector = 113;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 741
@@ -34933,6 +35336,7 @@ sidedef // 741
 sector = 113;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 742
@@ -34940,6 +35344,7 @@ sidedef // 742
 sector = 114;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 743
@@ -34951,18 +35356,21 @@ sidedef // 744
 {
 sector = 114;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 745
 {
 sector = 114;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 746
 {
 sector = 115;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 747
@@ -34974,6 +35382,7 @@ sidedef // 748
 {
 sector = 115;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 749
@@ -34981,6 +35390,7 @@ sidedef // 749
 sector = 115;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 750
@@ -34988,6 +35398,7 @@ sidedef // 750
 sector = 116;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 751
@@ -34999,18 +35410,21 @@ sidedef // 752
 {
 sector = 116;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 753
 {
 sector = 116;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 754
 {
 sector = 117;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 755
@@ -35022,6 +35436,7 @@ sidedef // 756
 {
 sector = 117;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 757
@@ -35029,12 +35444,14 @@ sidedef // 757
 sector = 117;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 758
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 759
@@ -35047,6 +35464,7 @@ sidedef // 760
 sector = 118;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 761
@@ -35058,18 +35476,21 @@ sidedef // 762
 {
 sector = 118;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 763
 {
 sector = 118;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 764
 {
 sector = 119;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 765
@@ -35081,6 +35502,7 @@ sidedef // 766
 {
 sector = 119;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 767
@@ -35088,6 +35510,7 @@ sidedef // 767
 sector = 119;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 768
@@ -35095,6 +35518,7 @@ sidedef // 768
 sector = 120;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 769
@@ -35106,12 +35530,14 @@ sidedef // 770
 {
 sector = 120;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 771
 {
 sector = 121;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 772
@@ -35119,12 +35545,14 @@ sidedef // 772
 sector = 121;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 773
 {
 sector = 121;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 774
@@ -35132,12 +35560,14 @@ sidedef // 774
 sector = 121;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 775
 {
 sector = 121;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 776
@@ -35145,6 +35575,7 @@ sidedef // 776
 sector = 121;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 777
@@ -35156,6 +35587,7 @@ sidedef // 778
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 779
@@ -35168,6 +35600,7 @@ sidedef // 780
 sector = 121;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 781
@@ -35184,12 +35617,14 @@ sidedef // 783
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 784
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 785
@@ -35201,6 +35636,7 @@ sidedef // 786
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 787
@@ -35213,6 +35649,7 @@ sidedef // 788
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 789
@@ -35230,6 +35667,7 @@ sidedef // 791
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 792
@@ -35247,6 +35685,7 @@ sidedef // 794
 {
 sector = 122;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 795
@@ -35276,6 +35715,7 @@ sidedef // 799
 sector = 0;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 800
@@ -35294,6 +35734,7 @@ sidedef // 802
 sector = 123;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 803
@@ -35322,6 +35763,7 @@ sidedef // 807
 {
 sector = 0;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 808
@@ -35341,6 +35783,7 @@ sidedef // 810
 sector = 121;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 811
@@ -35354,6 +35797,7 @@ sidedef // 812
 sector = 121;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 813
@@ -35377,6 +35821,7 @@ sidedef // 816
 sector = 121;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 817
@@ -35399,6 +35844,7 @@ sidedef // 820
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 821
@@ -35421,6 +35867,7 @@ sidedef // 824
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 825
@@ -35434,6 +35881,7 @@ sidedef // 826
 sector = 121;
 offsety = 42;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 827
@@ -35445,6 +35893,7 @@ sidedef // 828
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 829
@@ -35458,6 +35907,7 @@ sidedef // 830
 sector = 121;
 offsety = 42;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 831
@@ -35470,6 +35920,7 @@ sidedef // 832
 sector = 211;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 833
@@ -35477,12 +35928,14 @@ sidedef // 833
 sector = 128;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 834
 {
 sector = 128;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 835
@@ -35490,6 +35943,7 @@ sidedef // 835
 sector = 128;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 836
@@ -35497,6 +35951,8 @@ sidedef // 836
 sector = 66;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = 0.0;
+offsetx_bottom = 0.0;
 }
 
 sidedef // 837
@@ -35508,6 +35964,7 @@ sidedef // 838
 {
 sector = 128;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 839
@@ -35515,12 +35972,14 @@ sidedef // 839
 sector = 128;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 840
 {
 sector = 128;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 841
@@ -35528,6 +35987,7 @@ sidedef // 841
 sector = 101;
 offsetx = -64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 842
@@ -35541,6 +36001,7 @@ sidedef // 843
 sector = 66;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 844
@@ -35559,12 +36020,14 @@ sidedef // 846
 sector = 129;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 847
 {
 sector = 129;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 848
@@ -35593,6 +36056,7 @@ sidedef // 852
 {
 sector = 129;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 853
@@ -35600,6 +36064,7 @@ sidedef // 853
 sector = 129;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 854
@@ -35617,6 +36082,7 @@ sidedef // 856
 {
 sector = 130;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 857
@@ -35624,6 +36090,7 @@ sidedef // 857
 sector = 66;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 858
@@ -35631,12 +36098,14 @@ sidedef // 858
 sector = 130;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 859
 {
 sector = 130;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 860
@@ -35644,6 +36113,8 @@ sidedef // 860
 sector = 66;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = 0.0;
+offsetx_bottom = 0.0;
 }
 
 sidedef // 861
@@ -35655,6 +36126,7 @@ sidedef // 862
 {
 sector = 130;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 863
@@ -35687,6 +36159,7 @@ sidedef // 867
 sector = 231;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 868
@@ -35695,6 +36168,8 @@ sector = 183;
 offsetx = -64;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = -64.0;
+offsetx_bottom = -64.0;
 }
 
 sidedef // 869
@@ -35708,6 +36183,7 @@ sidedef // 870
 sector = 130;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 871
@@ -35715,6 +36191,7 @@ sidedef // 871
 sector = 130;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 872
@@ -35722,6 +36199,7 @@ sidedef // 872
 sector = 130;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 873
@@ -35729,6 +36207,7 @@ sidedef // 873
 sector = 130;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 874
@@ -35736,6 +36215,7 @@ sidedef // 874
 sector = 130;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 875
@@ -35743,6 +36223,7 @@ sidedef // 875
 sector = 66;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 876
@@ -35755,6 +36236,7 @@ sidedef // 877
 sector = 131;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 878
@@ -35762,12 +36244,14 @@ sidedef // 878
 sector = 131;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 879
 {
 sector = 131;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 880
@@ -35775,12 +36259,14 @@ sidedef // 880
 sector = 66;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 881
 {
 sector = 132;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 882
@@ -35788,6 +36274,7 @@ sidedef // 882
 sector = 131;
 offsetx = 64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 883
@@ -35800,6 +36287,7 @@ sidedef // 884
 sector = 132;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 885
@@ -35820,18 +36308,21 @@ sidedef // 887
 sector = 232;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 888
 {
 sector = 131;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 889
 {
 sector = 140;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 890
@@ -35844,6 +36335,7 @@ sidedef // 891
 sector = 139;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 892
@@ -35851,6 +36343,7 @@ sidedef // 892
 sector = 133;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 893
@@ -35862,6 +36355,7 @@ sidedef // 894
 {
 sector = 133;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 895
@@ -35869,18 +36363,21 @@ sidedef // 895
 sector = 133;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 896
 {
 sector = 134;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 897
 {
 sector = 136;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 898
@@ -35892,18 +36389,21 @@ sidedef // 899
 {
 sector = 144;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 900
 {
 sector = 136;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 901
 {
 sector = 134;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 902
@@ -35916,6 +36416,7 @@ sidedef // 903
 {
 sector = 134;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 904
@@ -35923,6 +36424,8 @@ sidedef // 904
 sector = 136;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = 0.0;
+offsetx_bottom = 0.0;
 }
 
 sidedef // 905
@@ -35934,6 +36437,7 @@ sidedef // 906
 {
 sector = 136;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 907
@@ -35942,6 +36446,8 @@ sector = 134;
 offsetx = -64;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = 64.0;
+offsetx_bottom = 64.0;
 }
 
 sidedef // 908
@@ -35955,12 +36461,14 @@ sidedef // 909
 sector = 136;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 910
 {
 sector = 134;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 911
@@ -35973,6 +36481,7 @@ sidedef // 912
 sector = 136;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 913
@@ -35980,6 +36489,7 @@ sidedef // 913
 sector = 134;
 texturetop = "VRTEX4";
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 914
@@ -35987,12 +36497,14 @@ sidedef // 914
 sector = 135;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 915
 {
 sector = 136;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 916
@@ -36001,18 +36513,21 @@ sector = 134;
 offsetx = -64;
 texturetop = "VRTEX4";
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 917
 {
 sector = 135;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 918
 {
 sector = 137;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 919
@@ -36020,6 +36535,7 @@ sidedef // 919
 sector = 138;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 920
@@ -36027,6 +36543,7 @@ sidedef // 920
 sector = 137;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 921
@@ -36044,6 +36561,7 @@ sidedef // 923
 {
 sector = 139;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 924
@@ -36051,6 +36569,7 @@ sidedef // 924
 sector = 140;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 925
@@ -36074,6 +36593,7 @@ sidedef // 928
 {
 sector = 139;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 929
@@ -36081,6 +36601,7 @@ sidedef // 929
 sector = 138;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 930
@@ -36098,13 +36619,11 @@ texturebottom = "VRTEX3";
 sidedef // 932
 {
 sector = 139;
-offsetx = 64;
 }
 
 sidedef // 933
 {
 sector = 138;
-offsetx = 64;
 texturebottom = "VRTEX2";
 }
 
@@ -36125,18 +36644,19 @@ sidedef // 936
 sector = 134;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 937
 {
 sector = 140;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 938
 {
 sector = 140;
-offsetx = 128;
 }
 
 sidedef // 939
@@ -36150,6 +36670,7 @@ sidedef // 940
 sector = 6;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 941
@@ -36178,6 +36699,7 @@ sidedef // 945
 {
 sector = 7;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 946
@@ -36196,6 +36718,7 @@ sidedef // 948
 sector = 131;
 offsetx = 64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 949
@@ -36219,6 +36742,7 @@ sidedef // 952
 {
 sector = 131;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 953
@@ -36303,6 +36827,7 @@ sidedef // 967
 sector = 7;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 968
@@ -36311,6 +36836,8 @@ sector = 54;
 offsetx = 64;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = -64.0;
+offsetx_bottom = -64.0;
 }
 
 sidedef // 969
@@ -36323,12 +36850,14 @@ sidedef // 970
 sector = 7;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 971
 {
 sector = 54;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 972
@@ -36336,18 +36865,21 @@ sidedef // 972
 sector = 144;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 973
 {
 sector = 144;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 974
 {
 sector = 144;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 975
@@ -36355,12 +36887,14 @@ sidedef // 975
 sector = 144;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 976
 {
 sector = 144;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 977
@@ -36500,6 +37034,7 @@ sidedef // 1001
 sector = 149;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1002
@@ -36507,6 +37042,7 @@ sidedef // 1002
 sector = 153;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1003
@@ -36524,6 +37060,7 @@ sidedef // 1005
 {
 sector = 155;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1006
@@ -36531,6 +37068,7 @@ sidedef // 1006
 sector = 153;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 1007
@@ -36538,6 +37076,7 @@ sidedef // 1007
 sector = 0;
 offsetx = -64;
 texturetop = "VRTEX4";
+offsetx_top = 64.0;
 }
 
 sidedef // 1008
@@ -36549,6 +37088,7 @@ sidedef // 1009
 {
 sector = 0;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1010
@@ -36556,6 +37096,7 @@ sidedef // 1010
 sector = 144;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1011
@@ -36567,12 +37108,14 @@ sidedef // 1012
 {
 sector = 150;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1013
 {
 sector = 150;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1014
@@ -36580,6 +37123,7 @@ sidedef // 1014
 sector = 149;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1015
@@ -36591,6 +37135,7 @@ sidedef // 1016
 {
 sector = 151;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1017
@@ -36598,6 +37143,7 @@ sidedef // 1017
 sector = 150;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 1018
@@ -36605,6 +37151,7 @@ sidedef // 1018
 sector = 151;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 1019
@@ -36616,12 +37163,14 @@ sidedef // 1020
 {
 sector = 152;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1021
 {
 sector = 151;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1022
@@ -36629,6 +37178,7 @@ sidedef // 1022
 sector = 152;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1023
@@ -36640,6 +37190,7 @@ sidedef // 1024
 {
 sector = 153;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1025
@@ -36647,6 +37198,7 @@ sidedef // 1025
 sector = 152;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 1026
@@ -36654,6 +37206,7 @@ sidedef // 1026
 sector = 153;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 1027
@@ -36665,6 +37218,7 @@ sidedef // 1028
 {
 sector = 148;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1029
@@ -36672,18 +37226,21 @@ sidedef // 1029
 sector = 148;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1030
 {
 sector = 153;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1031
 {
 sector = 154;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1032
@@ -36696,6 +37253,7 @@ sidedef // 1033
 sector = 148;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 1034
@@ -36703,12 +37261,14 @@ sidedef // 1034
 sector = 154;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 1035
 {
 sector = 156;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1036
@@ -36721,6 +37281,7 @@ sidedef // 1037
 sector = 154;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1038
@@ -36728,6 +37289,7 @@ sidedef // 1038
 sector = 156;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1039
@@ -36739,6 +37301,7 @@ sidedef // 1040
 {
 sector = 155;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1041
@@ -36746,6 +37309,7 @@ sidedef // 1041
 sector = 156;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 1042
@@ -36753,18 +37317,21 @@ sidedef // 1042
 sector = 155;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 1043
 {
 sector = 153;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1044
 {
 sector = 153;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1045
@@ -36773,6 +37340,8 @@ sector = 144;
 offsetx = -64;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = -64.0;
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1046
@@ -36783,7 +37352,8 @@ sector = 157;
 sidedef // 1047
 {
 sector = 157;
-offsety = -48;
+offsetx = 32;
+offsety = -16;
 texturemiddle = "VRTEX4";
 }
 
@@ -36792,12 +37362,14 @@ sidedef // 1048
 sector = 153;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1049
 {
 sector = 144;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1050
@@ -36806,6 +37378,8 @@ sector = 153;
 offsetx = -32;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = -32.0;
+offsetx_bottom = -32.0;
 }
 
 sidedef // 1051
@@ -36816,8 +37390,8 @@ sector = 157;
 sidedef // 1052
 {
 sector = 157;
-offsetx = -32;
-offsety = -48;
+offsetx = 32;
+offsety = -16;
 texturemiddle = "VRTEX4";
 }
 
@@ -36825,12 +37399,14 @@ sidedef // 1053
 {
 sector = 158;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1054
 {
 sector = 158;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1055
@@ -36838,6 +37414,7 @@ sidedef // 1055
 sector = 158;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1056
@@ -36845,6 +37422,7 @@ sidedef // 1056
 sector = 158;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1057
@@ -36852,12 +37430,14 @@ sidedef // 1057
 sector = 158;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1058
 {
 sector = 153;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 1059
@@ -36869,6 +37449,7 @@ sidedef // 1060
 {
 sector = 158;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1061
@@ -36876,6 +37457,7 @@ sidedef // 1061
 sector = 158;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1062
@@ -36883,6 +37465,7 @@ sidedef // 1062
 sector = 158;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1063
@@ -36890,18 +37473,21 @@ sidedef // 1063
 sector = 158;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1064
 {
 sector = 158;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1065
 {
 sector = 153;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 1066
@@ -36913,6 +37499,7 @@ sidedef // 1067
 {
 sector = 153;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1068
@@ -36920,6 +37507,7 @@ sidedef // 1068
 sector = 153;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1069
@@ -37203,6 +37791,7 @@ sidedef // 1117
 sector = 121;
 offsetx = 640;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1118
@@ -37229,6 +37818,7 @@ sidedef // 1122
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1123
@@ -37240,6 +37830,7 @@ sidedef // 1124
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1125
@@ -37262,6 +37853,7 @@ sidedef // 1128
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1129
@@ -37297,6 +37889,7 @@ sidedef // 1134
 sector = 121;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1135
@@ -37304,6 +37897,7 @@ sidedef // 1135
 sector = 172;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1136
@@ -37311,6 +37905,7 @@ sidedef // 1136
 sector = 176;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 1137
@@ -37334,12 +37929,14 @@ sidedef // 1140
 {
 sector = 173;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1141
 {
 sector = 173;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1142
@@ -37347,6 +37944,7 @@ sidedef // 1142
 sector = 172;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1143
@@ -37358,6 +37956,7 @@ sidedef // 1144
 {
 sector = 174;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1145
@@ -37365,6 +37964,7 @@ sidedef // 1145
 sector = 173;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 1146
@@ -37372,6 +37972,7 @@ sidedef // 1146
 sector = 174;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 1147
@@ -37383,12 +37984,14 @@ sidedef // 1148
 {
 sector = 175;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1149
 {
 sector = 174;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1150
@@ -37396,6 +37999,7 @@ sidedef // 1150
 sector = 175;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1151
@@ -37407,6 +38011,7 @@ sidedef // 1152
 {
 sector = 176;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1153
@@ -37414,6 +38019,7 @@ sidedef // 1153
 sector = 175;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 1154
@@ -37421,18 +38027,21 @@ sidedef // 1154
 sector = 211;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1155
 {
 sector = 176;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1156
 {
 sector = 0;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1157
@@ -37440,6 +38049,7 @@ sidedef // 1157
 sector = 177;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1158
@@ -37447,6 +38057,7 @@ sidedef // 1158
 sector = 144;
 offsetx = -64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 1159
@@ -37459,6 +38070,7 @@ sidedef // 1160
 sector = 177;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1161
@@ -37466,12 +38078,14 @@ sidedef // 1161
 sector = 179;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1162
 {
 sector = 144;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1163
@@ -37479,6 +38093,7 @@ sidedef // 1163
 sector = 178;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1164
@@ -37486,6 +38101,7 @@ sidedef // 1164
 sector = 144;
 offsetx = -64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 1165
@@ -37498,24 +38114,28 @@ sidedef // 1166
 sector = 178;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1167
 {
 sector = 183;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1168
 {
 sector = 144;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1169
 {
 sector = 183;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1170
@@ -37528,12 +38148,14 @@ sidedef // 1171
 sector = 183;
 offsetx = -64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 1172
 {
 sector = 183;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1173
@@ -37546,18 +38168,21 @@ sidedef // 1174
 sector = 183;
 offsetx = -64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 1175
 {
 sector = 183;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1176
 {
 sector = 183;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1177
@@ -37569,12 +38194,14 @@ sidedef // 1178
 {
 sector = 183;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1179
 {
 sector = 180;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1180
@@ -37586,6 +38213,7 @@ sidedef // 1181
 {
 sector = 183;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1182
@@ -37597,6 +38225,7 @@ sidedef // 1183
 {
 sector = 183;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1184
@@ -37608,6 +38237,7 @@ sidedef // 1185
 {
 sector = 183;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1186
@@ -37620,6 +38250,7 @@ sidedef // 1187
 sector = 183;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1188
@@ -37627,6 +38258,7 @@ sidedef // 1188
 sector = 183;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1189
@@ -37679,6 +38311,7 @@ sidedef // 1197
 sector = 183;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1198
@@ -37711,6 +38344,7 @@ sidedef // 1202
 {
 sector = 183;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1203
@@ -37723,6 +38357,7 @@ sidedef // 1204
 sector = 182;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1205
@@ -37730,6 +38365,7 @@ sidedef // 1205
 sector = 183;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 1206
@@ -37741,6 +38377,7 @@ sidedef // 1207
 {
 sector = 183;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1208
@@ -37757,6 +38394,7 @@ sidedef // 1210
 {
 sector = 179;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1211
@@ -37768,18 +38406,21 @@ sidedef // 1212
 {
 sector = 179;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1213
 {
 sector = 183;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1214
 {
 sector = 179;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1215
@@ -37792,12 +38433,14 @@ sidedef // 1216
 sector = 184;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 1217
 {
 sector = 184;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1218
@@ -37805,6 +38448,7 @@ sidedef // 1218
 sector = 184;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1219
@@ -37816,6 +38460,7 @@ sidedef // 1220
 {
 sector = 184;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1221
@@ -37827,6 +38472,7 @@ sidedef // 1222
 {
 sector = 185;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1223
@@ -37834,12 +38480,14 @@ sidedef // 1223
 sector = 185;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1224
 {
 sector = 185;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1225
@@ -37851,6 +38499,7 @@ sidedef // 1226
 {
 sector = 185;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1227
@@ -37863,12 +38512,14 @@ sidedef // 1228
 sector = 186;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 1229
 {
 sector = 186;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 1230
@@ -37881,6 +38532,7 @@ sidedef // 1231
 sector = 186;
 offsetx = -64;
 texturetop = "VRTEX4";
+offsetx_top = 64.0;
 }
 
 sidedef // 1232
@@ -37897,12 +38549,14 @@ sidedef // 1234
 {
 sector = 186;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1235
 {
 sector = 187;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1236
@@ -37910,18 +38564,21 @@ sidedef // 1236
 sector = 187;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1237
 {
 sector = 187;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1238
 {
 sector = 188;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1239
@@ -37940,6 +38597,7 @@ sidedef // 1241
 sector = 188;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1242
@@ -38121,6 +38779,7 @@ sidedef // 1273
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1274
@@ -38133,6 +38792,7 @@ sidedef // 1275
 sector = 126;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 1276
@@ -38145,6 +38805,7 @@ sidedef // 1277
 sector = 121;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1278
@@ -38156,6 +38817,7 @@ sidedef // 1279
 {
 sector = 198;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 1280
@@ -38168,6 +38830,7 @@ sidedef // 1281
 sector = 121;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1282
@@ -38180,6 +38843,7 @@ sidedef // 1283
 sector = 126;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1284
@@ -38192,6 +38856,7 @@ sidedef // 1285
 sector = 121;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 1286
@@ -38215,6 +38880,7 @@ sidedef // 1289
 sector = 197;
 offsetx = 256;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1290
@@ -38228,6 +38894,7 @@ sidedef // 1291
 sector = 121;
 offsetx = 512;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1292
@@ -38240,6 +38907,7 @@ sidedef // 1293
 sector = 195;
 offsetx = 128;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1294
@@ -38253,6 +38921,7 @@ sidedef // 1295
 sector = 121;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1296
@@ -38264,12 +38933,14 @@ sidedef // 1297
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1298
 {
 sector = 325;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1299
@@ -38282,6 +38953,7 @@ sidedef // 1300
 sector = 121;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1301
@@ -38301,6 +38973,7 @@ sidedef // 1303
 {
 sector = 121;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1304
@@ -38312,6 +38985,7 @@ sidedef // 1305
 {
 sector = 121;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1306
@@ -38583,6 +39257,7 @@ sidedef // 1352
 {
 sector = 206;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1353
@@ -38594,6 +39269,7 @@ sidedef // 1354
 {
 sector = 206;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 1355
@@ -38606,6 +39282,7 @@ sidedef // 1356
 sector = 206;
 offsetx = -64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 1357
@@ -38618,6 +39295,7 @@ sidedef // 1358
 sector = 206;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1359
@@ -38629,6 +39307,7 @@ sidedef // 1360
 {
 sector = 207;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1361
@@ -38636,18 +39315,21 @@ sidedef // 1361
 sector = 207;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1362
 {
 sector = 207;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1363
 {
 sector = 208;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1364
@@ -38666,6 +39348,7 @@ sidedef // 1366
 sector = 208;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1367
@@ -38673,12 +39356,14 @@ sidedef // 1367
 sector = 209;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1368
 {
 sector = 211;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1369
@@ -38686,6 +39371,7 @@ sidedef // 1369
 sector = 210;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1370
@@ -38697,12 +39383,14 @@ sidedef // 1371
 {
 sector = 210;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1372
 {
 sector = 211;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1373
@@ -38714,42 +39402,49 @@ sidedef // 1374
 {
 sector = 212;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1375
 {
 sector = 211;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1376
 {
 sector = 211;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 1377
 {
 sector = 209;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1378
 {
 sector = 211;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1379
 {
 sector = 211;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 1380
 {
 sector = 209;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1381
@@ -38762,18 +39457,21 @@ sidedef // 1382
 sector = 212;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 1383
 {
 sector = 212;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1384
 {
 sector = 209;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1385
@@ -38781,6 +39479,7 @@ sidedef // 1385
 sector = 212;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1386
@@ -38792,12 +39491,14 @@ sidedef // 1387
 {
 sector = 210;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1388
 {
 sector = 210;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1389
@@ -38815,6 +39516,7 @@ sidedef // 1391
 sector = 211;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1392
@@ -38822,12 +39524,14 @@ sidedef // 1392
 sector = 213;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1393
 {
 sector = 213;
 texturebottom = "VRTEX4";
+offsetx_bottom = -96.0;
 }
 
 sidedef // 1394
@@ -38840,6 +39544,7 @@ sidedef // 1395
 {
 sector = 213;
 texturebottom = "VRTEX4";
+offsetx_bottom = -96.0;
 }
 
 sidedef // 1396
@@ -38852,12 +39557,14 @@ sidedef // 1397
 {
 sector = 213;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1398
 {
 sector = 213;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1399
@@ -38870,6 +39577,7 @@ sidedef // 1400
 {
 sector = 213;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1401
@@ -38882,6 +39590,7 @@ sidedef // 1402
 {
 sector = 211;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1403
@@ -38889,12 +39598,14 @@ sidedef // 1403
 sector = 211;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1404
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1405
@@ -38911,6 +39622,7 @@ sidedef // 1407
 {
 sector = 215;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1408
@@ -38923,6 +39635,7 @@ sidedef // 1409
 sector = 215;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1410
@@ -38930,6 +39643,7 @@ sidedef // 1410
 sector = 211;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1411
@@ -38942,12 +39656,15 @@ sidedef // 1412
 sector = 274;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
+offsetx_mid = 96.0;
 }
 
 sidedef // 1413
 {
 sector = 215;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1414
@@ -38960,6 +39677,7 @@ sidedef // 1415
 sector = 211;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1416
@@ -38971,6 +39689,7 @@ sidedef // 1417
 {
 sector = 215;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1418
@@ -38978,6 +39697,8 @@ sidedef // 1418
 sector = 211;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1419
@@ -38990,6 +39711,7 @@ sidedef // 1420
 sector = 211;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1421
@@ -39001,6 +39723,7 @@ sidedef // 1422
 {
 sector = 243;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1423
@@ -39013,6 +39736,7 @@ sidedef // 1424
 {
 sector = 215;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 1425
@@ -39025,6 +39749,7 @@ sidedef // 1426
 sector = 215;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1427
@@ -39042,6 +39767,7 @@ sidedef // 1429
 sector = 215;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1430
@@ -39053,6 +39779,7 @@ sidedef // 1431
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 1432
@@ -39065,6 +39792,7 @@ sidedef // 1433
 sector = 211;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1434
@@ -39077,6 +39805,7 @@ sidedef // 1435
 {
 sector = 275;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1436
@@ -39084,6 +39813,8 @@ sidedef // 1436
 sector = 211;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1437
@@ -39095,6 +39826,7 @@ sidedef // 1438
 {
 sector = 215;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1439
@@ -39107,6 +39839,7 @@ sidedef // 1440
 sector = 215;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1441
@@ -39118,11 +39851,13 @@ sidedef // 1442
 {
 sector = 246;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1443
 {
 sector = 245;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1444
@@ -39177,6 +39912,8 @@ sidedef // 1452
 {
 sector = 218;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1453
@@ -39188,6 +39925,8 @@ sidedef // 1454
 {
 sector = 218;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1455
@@ -39199,6 +39938,8 @@ sidedef // 1456
 {
 sector = 218;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1457
@@ -39210,6 +39951,8 @@ sidedef // 1458
 {
 sector = 218;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1459
@@ -39270,12 +40013,14 @@ sidedef // 1468
 sector = 225;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1469
 {
 sector = 225;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1470
@@ -39283,6 +40028,7 @@ sidedef // 1470
 sector = 225;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1471
@@ -39290,6 +40036,7 @@ sidedef // 1471
 sector = 211;
 offsetx = -64;
 texturetop = "VRTEX4";
+offsetx_top = 64.0;
 }
 
 sidedef // 1472
@@ -39301,6 +40048,7 @@ sidedef // 1473
 {
 sector = 225;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1474
@@ -39308,6 +40056,7 @@ sidedef // 1474
 sector = 225;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1475
@@ -39315,6 +40064,7 @@ sidedef // 1475
 sector = 221;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1476
@@ -39322,18 +40072,21 @@ sidedef // 1476
 sector = 176;
 offsetx = -64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 1477
 {
 sector = 221;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1478
 {
 sector = 183;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 1479
@@ -39345,6 +40098,7 @@ sidedef // 1480
 {
 sector = 225;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1481
@@ -39352,12 +40106,14 @@ sidedef // 1481
 sector = 225;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1482
 {
 sector = 225;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1483
@@ -39365,18 +40121,21 @@ sidedef // 1483
 sector = 225;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1484
 {
 sector = 225;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1485
 {
 sector = 225;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1486
@@ -39384,6 +40143,7 @@ sidedef // 1486
 sector = 225;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1487
@@ -39391,12 +40151,14 @@ sidedef // 1487
 sector = 183;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1488
 {
 sector = 222;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1489
@@ -39409,6 +40171,7 @@ sidedef // 1490
 sector = 221;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = 96.0;
 }
 
 sidedef // 1491
@@ -39416,12 +40179,14 @@ sidedef // 1491
 sector = 222;
 offsetx = -32;
 texturemiddle = "VRTEX4";
+offsetx_mid = 96.0;
 }
 
 sidedef // 1492
 {
 sector = 223;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1493
@@ -39434,18 +40199,21 @@ sidedef // 1494
 sector = 222;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1495
 {
 sector = 223;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1496
 {
 sector = 224;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1497
@@ -39458,6 +40226,7 @@ sidedef // 1498
 sector = 223;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 1499
@@ -39465,6 +40234,7 @@ sidedef // 1499
 sector = 224;
 offsetx = -96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 1500
@@ -39476,6 +40246,7 @@ sidedef // 1501
 {
 sector = 224;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 1502
@@ -39483,12 +40254,14 @@ sidedef // 1502
 sector = 224;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1503
 {
 sector = 225;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1504
@@ -39715,6 +40488,7 @@ sidedef // 1544
 {
 sector = 183;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1545
@@ -39732,12 +40506,14 @@ sidedef // 1547
 sector = 232;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1548
 {
 sector = 231;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1549
@@ -39754,6 +40530,7 @@ sidedef // 1551
 {
 sector = 130;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1552
@@ -39880,12 +40657,14 @@ sidedef // 1574
 sector = 235;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1575
 {
 sector = 183;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1576
@@ -39914,6 +40693,7 @@ sidedef // 1580
 sector = 234;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1581
@@ -39975,6 +40755,7 @@ sidedef // 1591
 {
 sector = 238;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1592
@@ -40036,12 +40817,14 @@ sidedef // 1602
 {
 sector = 241;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1603
 {
 sector = 241;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1604
@@ -40049,12 +40832,14 @@ sidedef // 1604
 sector = 241;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1605
 {
 sector = 225;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 1606
@@ -40066,6 +40851,7 @@ sidedef // 1607
 {
 sector = 241;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1608
@@ -40073,18 +40859,21 @@ sidedef // 1608
 sector = 241;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1609
 {
 sector = 241;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1610
 {
 sector = 183;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 1611
@@ -40097,6 +40886,7 @@ sidedef // 1612
 sector = 183;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1613
@@ -40104,12 +40894,14 @@ sidedef // 1613
 sector = 225;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1614
 {
 sector = 241;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1615
@@ -40117,6 +40909,7 @@ sidedef // 1615
 sector = 241;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1616
@@ -40124,6 +40917,7 @@ sidedef // 1616
 sector = 144;
 offsetx = -64;
 texturetop = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 1617
@@ -40136,6 +40930,7 @@ sidedef // 1618
 sector = 241;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1619
@@ -40143,6 +40938,7 @@ sidedef // 1619
 sector = 241;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1620
@@ -40150,18 +40946,21 @@ sidedef // 1620
 sector = 241;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1621
 {
 sector = 144;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1622
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1623
@@ -40173,6 +40972,8 @@ sidedef // 1624
 {
 sector = 257;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1625
@@ -40185,6 +40986,7 @@ sidedef // 1626
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1627
@@ -40196,6 +40998,7 @@ sidedef // 1628
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1629
@@ -40207,6 +41010,7 @@ sidedef // 1630
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1631
@@ -40219,6 +41023,8 @@ sidedef // 1632
 sector = 243;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1633
@@ -40232,11 +41038,13 @@ sidedef // 1634
 {
 sector = 248;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1635
 {
 sector = 247;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1636
@@ -40244,6 +41052,8 @@ sidedef // 1636
 sector = 244;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_mid = -96.0;
+offsetx_bottom = -96.0;
 }
 
 sidedef // 1637
@@ -40257,28 +41067,33 @@ sidedef // 1638
 {
 sector = 244;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1639
 {
 sector = 243;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1640
 {
 sector = 245;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1641
 {
 sector = 244;
+offsetx_mid = -64.0;
 }
 
 sidedef // 1642
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1643
@@ -40290,6 +41105,7 @@ sidedef // 1644
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1645
@@ -40301,6 +41117,8 @@ sidedef // 1646
 {
 sector = 245;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1647
@@ -40314,11 +41132,13 @@ sidedef // 1648
 {
 sector = 250;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1649
 {
 sector = 249;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1650
@@ -40326,6 +41146,8 @@ sidedef // 1650
 sector = 246;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_mid = -32.0;
+offsetx_bottom = -32.0;
 }
 
 sidedef // 1651
@@ -40339,17 +41161,20 @@ sidedef // 1652
 {
 sector = 247;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1653
 {
 sector = 246;
+offsetx_mid = -64.0;
 }
 
 sidedef // 1654
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1655
@@ -40361,6 +41186,7 @@ sidedef // 1656
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1657
@@ -40373,6 +41199,8 @@ sidedef // 1658
 sector = 247;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1659
@@ -40386,11 +41214,13 @@ sidedef // 1660
 {
 sector = 252;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1661
 {
 sector = 251;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1662
@@ -40398,6 +41228,8 @@ sidedef // 1662
 sector = 248;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_mid = -96.0;
+offsetx_bottom = -96.0;
 }
 
 sidedef // 1663
@@ -40411,17 +41243,20 @@ sidedef // 1664
 {
 sector = 249;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1665
 {
 sector = 248;
+offsetx_mid = 64.0;
 }
 
 sidedef // 1666
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1667
@@ -40433,6 +41268,7 @@ sidedef // 1668
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1669
@@ -40444,6 +41280,8 @@ sidedef // 1670
 {
 sector = 249;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
+offsetx_mid = -64.0;
 }
 
 sidedef // 1671
@@ -40451,17 +41289,20 @@ sidedef // 1671
 sector = 215;
 offsetx = 288;
 texturebottom = "VRTEX4";
+offsetx_mid = 96.0;
 }
 
 sidedef // 1672
 {
 sector = 254;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1673
 {
 sector = 253;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1674
@@ -40469,6 +41310,8 @@ sidedef // 1674
 sector = 250;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_mid = 96.0;
+offsetx_bottom = 96.0;
 }
 
 sidedef // 1675
@@ -40476,23 +41319,27 @@ sidedef // 1675
 sector = 215;
 offsetx = 256;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1676
 {
 sector = 251;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1677
 {
 sector = 250;
+offsetx_mid = 64.0;
 }
 
 sidedef // 1678
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1679
@@ -40504,6 +41351,7 @@ sidedef // 1680
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1681
@@ -40516,6 +41364,8 @@ sidedef // 1682
 sector = 251;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1683
@@ -40523,17 +41373,20 @@ sidedef // 1683
 sector = 215;
 offsetx = 224;
 texturebottom = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 1684
 {
 sector = 256;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1685
 {
 sector = 255;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1686
@@ -40541,6 +41394,8 @@ sidedef // 1686
 sector = 252;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_mid = -96.0;
+offsetx_bottom = -96.0;
 }
 
 sidedef // 1687
@@ -40548,23 +41403,27 @@ sidedef // 1687
 sector = 215;
 offsetx = 192;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1688
 {
 sector = 253;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1689
 {
 sector = 252;
+offsetx_mid = 64.0;
 }
 
 sidedef // 1690
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1691
@@ -40576,6 +41435,7 @@ sidedef // 1692
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1693
@@ -40587,6 +41447,8 @@ sidedef // 1694
 {
 sector = 253;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
+offsetx_bottom = -64.0;
 }
 
 sidedef // 1695
@@ -40600,11 +41462,13 @@ sidedef // 1696
 {
 sector = 242;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1697
 {
 sector = 257;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1698
@@ -40612,6 +41476,8 @@ sidedef // 1698
 sector = 254;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_mid = 96.0;
+offsetx_bottom = 96.0;
 }
 
 sidedef // 1699
@@ -40619,23 +41485,27 @@ sidedef // 1699
 sector = 215;
 offsetx = 128;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1700
 {
 sector = 255;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1701
 {
 sector = 254;
+offsetx_mid = 64.0;
 }
 
 sidedef // 1702
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1703
@@ -40647,6 +41517,7 @@ sidedef // 1704
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1705
@@ -40659,6 +41530,8 @@ sidedef // 1706
 sector = 255;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1707
@@ -40666,6 +41539,7 @@ sidedef // 1707
 sector = 215;
 offsetx = 96;
 texturebottom = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 1708
@@ -40673,6 +41547,8 @@ sidedef // 1708
 sector = 242;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_mid = 96.0;
+offsetx_bottom = 96.0;
 }
 
 sidedef // 1709
@@ -40685,29 +41561,35 @@ sidedef // 1710
 sector = 256;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_mid = -96.0;
+offsetx_bottom = -96.0;
 }
 
 sidedef // 1711
 {
 sector = 215;
 offsetx = 64;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1712
 {
 sector = 257;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1713
 {
 sector = 256;
+offsetx_mid = 64.0;
 }
 
 sidedef // 1714
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1715
@@ -40719,6 +41601,7 @@ sidedef // 1716
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1717
@@ -41111,23 +41994,27 @@ sidedef // 1783
 {
 sector = 211;
 offsetx = 32;
+offsetx_mid = 32.0;
 }
 
 sidedef // 1784
 {
 sector = 278;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1785
 {
 sector = 277;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1786
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1787
@@ -41145,12 +42032,14 @@ sidedef // 1789
 {
 sector = 211;
 offsetx = 32;
+offsetx_mid = 32.0;
 }
 
 sidedef // 1790
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1791
@@ -41163,6 +42052,8 @@ sidedef // 1792
 sector = 275;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1793
@@ -41177,6 +42068,8 @@ sidedef // 1794
 sector = 276;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
+offsetx_mid = 32.0;
 }
 
 sidedef // 1795
@@ -41197,17 +42090,20 @@ sidedef // 1797
 sector = 211;
 offsetx = 480;
 texturebottom = "VRTEX4";
+offsetx_mid = 96.0;
 }
 
 sidedef // 1798
 {
 sector = 280;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1799
 {
 sector = 279;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1800
@@ -41222,12 +42118,14 @@ sidedef // 1801
 sector = 211;
 offsetx = 448;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1802
 {
 sector = 276;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1803
@@ -41239,17 +42137,21 @@ sidedef // 1804
 {
 sector = 277;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1805
 {
 sector = 276;
+offsetx_mid = -64.0;
 }
 
 sidedef // 1806
 {
 sector = 277;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
+offsetx_mid = 64.0;
 }
 
 sidedef // 1807
@@ -41264,6 +42166,8 @@ sidedef // 1808
 sector = 278;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
+offsetx_mid = 96.0;
 }
 
 sidedef // 1809
@@ -41284,17 +42188,20 @@ sidedef // 1811
 sector = 211;
 offsetx = 416;
 texturebottom = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 1812
 {
 sector = 282;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1813
 {
 sector = 281;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1814
@@ -41309,17 +42216,20 @@ sidedef // 1815
 sector = 211;
 offsetx = 384;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1816
 {
 sector = 279;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1817
 {
 sector = 278;
+offsetx_mid = -64.0;
 }
 
 sidedef // 1818
@@ -41327,6 +42237,8 @@ sidedef // 1818
 sector = 279;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1819
@@ -41341,6 +42253,8 @@ sidedef // 1820
 sector = 280;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
+offsetx_mid = 32.0;
 }
 
 sidedef // 1821
@@ -41361,17 +42275,20 @@ sidedef // 1823
 sector = 211;
 offsetx = 352;
 texturebottom = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 1824
 {
 sector = 284;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1825
 {
 sector = 283;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1826
@@ -41386,23 +42303,28 @@ sidedef // 1827
 sector = 211;
 offsetx = 320;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1828
 {
 sector = 281;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1829
 {
 sector = 280;
+offsetx_mid = -64.0;
 }
 
 sidedef // 1830
 {
 sector = 281;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
+offsetx_mid = 64.0;
 }
 
 sidedef // 1831
@@ -41417,6 +42339,8 @@ sidedef // 1832
 sector = 282;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
+offsetx_mid = 96.0;
 }
 
 sidedef // 1833
@@ -41437,17 +42361,20 @@ sidedef // 1835
 sector = 211;
 offsetx = 288;
 texturebottom = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 1836
 {
 sector = 286;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1837
 {
 sector = 285;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1838
@@ -41462,17 +42389,20 @@ sidedef // 1839
 sector = 211;
 offsetx = 256;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1840
 {
 sector = 283;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1841
 {
 sector = 282;
+offsetx_mid = -64.0;
 }
 
 sidedef // 1842
@@ -41480,6 +42410,8 @@ sidedef // 1842
 sector = 283;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1843
@@ -41494,6 +42426,8 @@ sidedef // 1844
 sector = 284;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
+offsetx_mid = 32.0;
 }
 
 sidedef // 1845
@@ -41514,17 +42448,20 @@ sidedef // 1847
 sector = 211;
 offsetx = 224;
 texturebottom = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 1848
 {
 sector = 288;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1849
 {
 sector = 287;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1850
@@ -41539,23 +42476,28 @@ sidedef // 1851
 sector = 211;
 offsetx = 192;
 texturebottom = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 1852
 {
 sector = 285;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1853
 {
 sector = 284;
+offsetx_mid = -64.0;
 }
 
 sidedef // 1854
 {
 sector = 285;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
+offsetx_mid = 64.0;
 }
 
 sidedef // 1855
@@ -41570,6 +42512,8 @@ sidedef // 1856
 sector = 286;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
+offsetx_mid = 96.0;
 }
 
 sidedef // 1857
@@ -41590,6 +42534,7 @@ sidedef // 1859
 sector = 211;
 offsetx = 160;
 texturebottom = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 1860
@@ -41601,6 +42546,7 @@ texturebottom = "VRTEX4";
 sidedef // 1861
 {
 sector = 289;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1862
@@ -41615,17 +42561,20 @@ sidedef // 1863
 sector = 211;
 offsetx = 128;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 1864
 {
 sector = 287;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1865
 {
 sector = 286;
+offsetx_mid = -64.0;
 }
 
 sidedef // 1866
@@ -41633,6 +42582,8 @@ sidedef // 1866
 sector = 287;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1867
@@ -41647,6 +42598,8 @@ sidedef // 1868
 sector = 288;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
+offsetx_mid = 32.0;
 }
 
 sidedef // 1869
@@ -41667,6 +42620,7 @@ sidedef // 1871
 sector = 211;
 offsetx = 96;
 texturebottom = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 1872
@@ -41679,6 +42633,7 @@ texturebottom = "VRTEX4";
 sidedef // 1873
 {
 sector = 211;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1874
@@ -41692,23 +42647,28 @@ sidedef // 1875
 {
 sector = 211;
 offsetx = 64;
+offsetx_mid = -64.0;
 }
 
 sidedef // 1876
 {
 sector = 289;
 texturebottom = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 1877
 {
 sector = 288;
+offsetx_mid = -64.0;
 }
 
 sidedef // 1878
 {
 sector = 289;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
+offsetx_mid = 64.0;
 }
 
 sidedef // 1879
@@ -42103,6 +43063,7 @@ sidedef // 1945
 {
 sector = 213;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1946
@@ -42114,6 +43075,7 @@ offsetx = 1088;
 sidedef // 1947
 {
 sector = 213;
+offsetx_mid = -92.0;
 }
 
 sidedef // 1948
@@ -42125,6 +43087,7 @@ sidedef // 1949
 {
 sector = 213;
 texturebottom = "VRTEX4";
+offsetx_bottom = -92.0;
 }
 
 sidedef // 1950
@@ -42142,17 +43105,20 @@ sidedef // 1952
 {
 sector = 307;
 texturebottom = "VRTEX4";
+offsetx_bottom = -92.0;
 }
 
 sidedef // 1953
 {
 sector = 211;
+offsetx_mid = -92.0;
 }
 
 sidedef // 1954
 {
 sector = 213;
 offsetx = 64;
+offsetx_mid = -28.0;
 }
 
 sidedef // 1955
@@ -42169,6 +43135,7 @@ texturemiddle = "VRTEX4";
 sidedef // 1957
 {
 sector = 213;
+offsetx_mid = -92.0;
 }
 
 sidedef // 1958
@@ -42181,16 +43148,19 @@ sidedef // 1959
 {
 sector = 307;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 1960
 {
 sector = 211;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1961
 {
 sector = 213;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1962
@@ -42208,6 +43178,7 @@ texturemiddle = "VRTEX4";
 sidedef // 1964
 {
 sector = 308;
+offsetx_mid = -92.0;
 }
 
 sidedef // 1965
@@ -42218,6 +43189,7 @@ sector = 307;
 sidedef // 1966
 {
 sector = 213;
+offsetx_mid = -92.0;
 }
 
 sidedef // 1967
@@ -42240,12 +43212,14 @@ sector = 307;
 sidedef // 1970
 {
 sector = 308;
+offsetx_mid = 0.0;
 }
 
 sidedef // 1971
 {
 sector = 213;
 offsetx = 64;
+offsetx_mid = 64.0;
 }
 
 sidedef // 1972
@@ -42274,6 +43248,7 @@ texturemiddle = "VRTEX4";
 sidedef // 1976
 {
 sector = 213;
+offsetx_mid = 32.0;
 }
 
 sidedef // 1977
@@ -42285,17 +43260,20 @@ sidedef // 1978
 {
 sector = 307;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
 }
 
 sidedef // 1979
 {
 sector = 211;
+offsetx_mid = 32.0;
 }
 
 sidedef // 1980
 {
 sector = 213;
 offsetx = 64;
+offsetx_mid = 96.0;
 }
 
 sidedef // 1981
@@ -42306,6 +43284,7 @@ sector = 307;
 sidedef // 1982
 {
 sector = 213;
+offsetx_mid = -96.0;
 }
 
 sidedef // 1983
@@ -42318,16 +43297,19 @@ sidedef // 1984
 {
 sector = 307;
 texturebottom = "VRTEX4";
+offsetx_bottom = -96.0;
 }
 
 sidedef // 1985
 {
 sector = 211;
+offsetx_mid = -96.0;
 }
 
 sidedef // 1986
 {
 sector = 213;
+offsetx_mid = -96.0;
 }
 
 sidedef // 1987
@@ -42339,6 +43321,7 @@ offsetx = 64;
 sidedef // 1988
 {
 sector = 308;
+offsetx_mid = 32.0;
 }
 
 sidedef // 1989
@@ -42349,6 +43332,7 @@ sector = 307;
 sidedef // 1990
 {
 sector = 213;
+offsetx_mid = 32.0;
 }
 
 sidedef // 1991
@@ -42360,6 +43344,7 @@ offsetx = 64;
 sidedef // 1992
 {
 sector = 307;
+offsetx_mid = -96.0;
 }
 
 sidedef // 1993
@@ -42371,6 +43356,7 @@ sidedef // 1994
 {
 sector = 213;
 offsetx = 64;
+offsetx_mid = -32.0;
 }
 
 sidedef // 1995
@@ -42382,6 +43368,7 @@ sidedef // 1996
 {
 sector = 213;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
 }
 
 sidedef // 1997
@@ -42393,6 +43380,7 @@ sidedef // 1998
 {
 sector = 213;
 texturebottom = "VRTEX4";
+offsetx_bottom = -96.0;
 }
 
 sidedef // 1999
@@ -42406,6 +43394,7 @@ sidedef // 2000
 sector = 321;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2001
@@ -42413,6 +43402,7 @@ sidedef // 2001
 sector = 321;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2002
@@ -42421,6 +43411,7 @@ sector = 322;
 offsetx = 64;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = 64.0;
 }
 
 sidedef // 2003
@@ -42433,6 +43424,7 @@ sidedef // 2004
 sector = 321;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 2005
@@ -42440,6 +43432,7 @@ sidedef // 2005
 sector = 312;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2006
@@ -42447,6 +43440,7 @@ sidedef // 2006
 sector = 126;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 2007
@@ -42458,6 +43452,7 @@ sidedef // 2008
 {
 sector = 314;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2009
@@ -42470,6 +43465,7 @@ sidedef // 2010
 sector = 312;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2011
@@ -42477,6 +43473,7 @@ sidedef // 2011
 sector = 314;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2012
@@ -42488,24 +43485,28 @@ sidedef // 2013
 {
 sector = 313;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2014
 {
 sector = 314;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2015
 {
 sector = 313;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2016
 {
 sector = 315;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2017
@@ -42518,6 +43519,7 @@ sidedef // 2018
 sector = 313;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2019
@@ -42525,12 +43527,14 @@ sidedef // 2019
 sector = 315;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2020
 {
 sector = 316;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2021
@@ -42542,18 +43546,21 @@ sidedef // 2022
 {
 sector = 315;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2023
 {
 sector = 316;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2024
 {
 sector = 317;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2025
@@ -42566,6 +43573,7 @@ sidedef // 2026
 sector = 316;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2027
@@ -42573,12 +43581,14 @@ sidedef // 2027
 sector = 317;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2028
 {
 sector = 318;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2029
@@ -42590,18 +43600,21 @@ sidedef // 2030
 {
 sector = 317;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2031
 {
 sector = 318;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2032
 {
 sector = 319;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2033
@@ -42614,6 +43627,7 @@ sidedef // 2034
 sector = 318;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2035
@@ -42621,12 +43635,14 @@ sidedef // 2035
 sector = 319;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2036
 {
 sector = 320;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2037
@@ -42638,12 +43654,14 @@ sidedef // 2038
 {
 sector = 319;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2039
 {
 sector = 320;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2040
@@ -42655,18 +43673,21 @@ sidedef // 2041
 {
 sector = 320;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 2042
 {
 sector = 320;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2043
 {
 sector = 321;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2044
@@ -42678,6 +43699,7 @@ sidedef // 2045
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2046
@@ -42700,6 +43722,7 @@ sidedef // 2049
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2050
@@ -42707,6 +43730,7 @@ sidedef // 2050
 sector = 324;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2051
@@ -42714,6 +43738,7 @@ sidedef // 2051
 sector = 323;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2052
@@ -42721,6 +43746,7 @@ sidedef // 2052
 sector = 323;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2053
@@ -42729,6 +43755,7 @@ sector = 183;
 offsetx = -64;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX3";
+offsetx_top = 64.0;
 }
 
 sidedef // 2054
@@ -42741,6 +43768,7 @@ sidedef // 2055
 sector = 183;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2056
@@ -42758,24 +43786,28 @@ sidedef // 2058
 {
 sector = 323;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2059
 {
 sector = 324;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2060
 {
 sector = 326;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2061
 {
 sector = 325;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2062
@@ -42783,12 +43815,14 @@ sidedef // 2062
 sector = 410;
 offsetx = 176;
 texturemiddle = "VRTEX4";
+offsetx_mid = -80.0;
 }
 
 sidedef // 2063
 {
 sector = 325;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2064
@@ -42797,6 +43831,7 @@ sector = 197;
 offsetx = 64;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = -64.0;
 }
 
 sidedef // 2065
@@ -42808,6 +43843,7 @@ sidedef // 2066
 {
 sector = 326;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2067
@@ -42815,6 +43851,7 @@ sidedef // 2067
 sector = 143;
 offsetx = 184;
 texturemiddle = "VRTEX4";
+offsetx_mid = -72.0;
 }
 
 sidedef // 2068
@@ -42822,18 +43859,21 @@ sidedef // 2068
 sector = 410;
 offsetx = 168;
 texturemiddle = "VRTEX4";
+offsetx_mid = -88.0;
 }
 
 sidedef // 2069
 {
 sector = 326;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2070
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2071
@@ -42846,12 +43886,14 @@ sidedef // 2072
 {
 sector = 327;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2073
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2074
@@ -42864,6 +43906,7 @@ sidedef // 2075
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2076
@@ -42876,6 +43919,7 @@ sidedef // 2077
 {
 sector = 353;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2078
@@ -42888,6 +43932,7 @@ sidedef // 2079
 {
 sector = 353;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2080
@@ -42900,6 +43945,7 @@ sidedef // 2081
 {
 sector = 353;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2082
@@ -42913,6 +43959,7 @@ sidedef // 2083
 sector = 343;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2084
@@ -42931,12 +43978,14 @@ sidedef // 2086
 sector = 329;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2087
 {
 sector = 353;
 offsetx = 320;
+offsetx_mid = 64.0;
 }
 
 sidedef // 2088
@@ -42954,12 +44003,14 @@ sidedef // 2090
 {
 sector = 329;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2091
 {
 sector = 211;
 offsetx = 384;
+offsetx_mid = 0.0;
 }
 
 sidedef // 2092
@@ -42972,6 +44023,7 @@ sidedef // 2093
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2094
@@ -42985,6 +44037,7 @@ sidedef // 2095
 sector = 353;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2096
@@ -42997,6 +44050,7 @@ sidedef // 2097
 {
 sector = 353;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2098
@@ -43008,6 +44062,7 @@ sidedef // 2099
 {
 sector = 353;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2100
@@ -43018,7 +44073,6 @@ sector = 330;
 sidedef // 2101
 {
 sector = 353;
-offsetx = 64;
 texturebottom = "VRTEX2";
 }
 
@@ -43032,6 +44086,7 @@ sidedef // 2103
 sector = 334;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2104
@@ -43044,6 +44099,7 @@ sidedef // 2105
 sector = 334;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2106
@@ -43056,6 +44112,7 @@ sidedef // 2107
 {
 sector = 328;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2108
@@ -43068,6 +44125,7 @@ sidedef // 2109
 {
 sector = 339;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2110
@@ -43079,6 +44137,7 @@ sidedef // 2111
 {
 sector = 339;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2112
@@ -43091,6 +44150,7 @@ sidedef // 2113
 {
 sector = 344;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2114
@@ -43103,6 +44163,7 @@ sidedef // 2115
 {
 sector = 351;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2116
@@ -43116,6 +44177,7 @@ sidedef // 2117
 {
 sector = 353;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2118
@@ -43136,6 +44198,7 @@ sidedef // 2120
 sector = 331;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 2121
@@ -43147,6 +44210,7 @@ sidedef // 2122
 {
 sector = 331;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2123
@@ -43158,6 +44222,7 @@ sidedef // 2124
 {
 sector = 331;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2125
@@ -43169,6 +44234,7 @@ sidedef // 2126
 {
 sector = 331;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2127
@@ -43181,6 +44247,7 @@ sidedef // 2128
 sector = 331;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = -64.0;
 }
 
 sidedef // 2129
@@ -43192,6 +44259,7 @@ sidedef // 2130
 {
 sector = 331;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2131
@@ -43203,6 +44271,7 @@ sidedef // 2132
 {
 sector = 331;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2133
@@ -43214,6 +44283,7 @@ sidedef // 2134
 {
 sector = 353;
 offsetx = 64;
+offsetx_mid = 64.0;
 }
 
 sidedef // 2135
@@ -43226,6 +44296,7 @@ sidedef // 2136
 {
 sector = 353;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2137
@@ -43297,6 +44368,7 @@ sidedef // 2148
 {
 sector = 353;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2149
@@ -43310,6 +44382,7 @@ sidedef // 2150
 sector = 334;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2151
@@ -43322,6 +44395,7 @@ sidedef // 2152
 sector = 353;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
 }
 
 sidedef // 2153
@@ -43334,6 +44408,8 @@ sidedef // 2154
 sector = 353;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
+offsetx_mid = 64.0;
 }
 
 sidedef // 2155
@@ -43351,12 +44427,15 @@ sidedef // 2157
 {
 sector = 335;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2158
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
+offsetx_mid = 0.0;
 }
 
 sidedef // 2159
@@ -43375,12 +44454,14 @@ sidedef // 2161
 sector = 335;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2162
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2163
@@ -43394,6 +44475,7 @@ sidedef // 2164
 sector = 353;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2165
@@ -43412,6 +44494,7 @@ sidedef // 2167
 sector = 335;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2168
@@ -43419,6 +44502,8 @@ sidedef // 2168
 sector = 353;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
+offsetx_mid = 64.0;
 }
 
 sidedef // 2169
@@ -43436,12 +44521,15 @@ sidedef // 2171
 {
 sector = 335;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2172
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
+offsetx_mid = 0.0;
 }
 
 sidedef // 2173
@@ -43454,6 +44542,7 @@ sidedef // 2174
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2175
@@ -43467,6 +44556,7 @@ sidedef // 2176
 sector = 353;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2177
@@ -43477,7 +44567,7 @@ sector = 327;
 sidedef // 2178
 {
 sector = 336;
-offsety = -24;
+offsety = -48;
 texturemiddle = "VRTEX4";
 }
 
@@ -43533,6 +44623,7 @@ sidedef // 2187
 sector = 346;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 2188
@@ -43551,6 +44642,7 @@ sidedef // 2190
 sector = 346;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
 }
 
 sidedef // 2191
@@ -43569,6 +44661,7 @@ sidedef // 2193
 sector = 340;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 2194
@@ -43576,6 +44669,7 @@ sidedef // 2194
 sector = 339;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 2195
@@ -43589,6 +44683,7 @@ sidedef // 2196
 sector = 340;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
 }
 
 sidedef // 2197
@@ -43606,6 +44701,7 @@ sidedef // 2199
 {
 sector = 341;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2200
@@ -43613,6 +44709,7 @@ sidedef // 2200
 sector = 340;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2201
@@ -43625,6 +44722,7 @@ sidedef // 2202
 {
 sector = 341;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2203
@@ -43643,6 +44741,7 @@ sidedef // 2205
 sector = 342;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 2206
@@ -43650,6 +44749,7 @@ sidedef // 2206
 sector = 341;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
 }
 
 sidedef // 2207
@@ -43663,6 +44763,7 @@ sidedef // 2208
 sector = 342;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
 }
 
 sidedef // 2209
@@ -43679,6 +44780,7 @@ sidedef // 2211
 {
 sector = 343;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2212
@@ -43686,6 +44788,7 @@ sidedef // 2212
 sector = 342;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2213
@@ -43703,6 +44806,7 @@ sidedef // 2215
 {
 sector = 344;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2216
@@ -43710,6 +44814,7 @@ sidedef // 2216
 sector = 343;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2217
@@ -43727,6 +44832,7 @@ sidedef // 2219
 sector = 345;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 2220
@@ -43734,6 +44840,7 @@ sidedef // 2220
 sector = 345;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
 }
 
 sidedef // 2221
@@ -43754,6 +44861,8 @@ sidedef // 2223
 sector = 345;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
+offsetx_mid = 64.0;
 }
 
 sidedef // 2224
@@ -43765,6 +44874,7 @@ sidedef // 2225
 {
 sector = 338;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2226
@@ -43779,12 +44889,15 @@ sidedef // 2227
 sector = 344;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
+offsetx_mid = 96.0;
 }
 
 sidedef // 2228
 {
 sector = 338;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2229
@@ -43802,6 +44915,7 @@ sidedef // 2231
 {
 sector = 347;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2232
@@ -43809,6 +44923,8 @@ sidedef // 2232
 sector = 348;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
+offsetx_mid = 64.0;
 }
 
 sidedef // 2233
@@ -43821,6 +44937,7 @@ sidedef // 2234
 {
 sector = 347;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2235
@@ -43839,6 +44956,7 @@ sidedef // 2237
 sector = 348;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 2238
@@ -43846,6 +44964,8 @@ sidedef // 2238
 sector = 347;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
+offsetx_mid = 32.0;
 }
 
 sidedef // 2239
@@ -43859,6 +44979,7 @@ sidedef // 2240
 sector = 348;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
 }
 
 sidedef // 2241
@@ -43876,6 +44997,7 @@ sidedef // 2243
 {
 sector = 349;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2244
@@ -43883,6 +45005,8 @@ sidedef // 2244
 sector = 346;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
+offsetx_mid = 64.0;
 }
 
 sidedef // 2245
@@ -43895,6 +45019,7 @@ sidedef // 2246
 {
 sector = 349;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2247
@@ -43913,6 +45038,7 @@ sidedef // 2249
 sector = 350;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 2250
@@ -43927,6 +45053,8 @@ sidedef // 2251
 sector = 351;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
+offsetx_mid = 64.0;
 }
 
 sidedef // 2252
@@ -43934,6 +45062,7 @@ sidedef // 2252
 sector = 350;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
 }
 
 sidedef // 2253
@@ -43944,12 +45073,14 @@ sector = 330;
 sidedef // 2254
 {
 sector = 350;
+offsetx_mid = 96.0;
 }
 
 sidedef // 2255
 {
 sector = 352;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2256
@@ -43963,6 +45094,8 @@ sidedef // 2257
 sector = 352;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
+offsetx_mid = 32.0;
 }
 
 sidedef // 2258
@@ -43981,6 +45114,7 @@ sidedef // 2260
 sector = 353;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2261
@@ -43994,6 +45128,8 @@ sidedef // 2262
 {
 sector = 343;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
+offsetx_mid = 0.0;
 }
 
 sidedef // 2263
@@ -44001,6 +45137,7 @@ sidedef // 2263
 sector = 351;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 2264
@@ -44021,6 +45158,8 @@ sidedef // 2266
 sector = 350;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
+offsetx_mid = 64.0;
 }
 
 sidedef // 2267
@@ -44033,6 +45172,7 @@ sidedef // 2268
 sector = 351;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 2269
@@ -44046,6 +45186,7 @@ sidedef // 2270
 sector = 353;
 offsetx = -32;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 2271
@@ -44077,6 +45218,8 @@ sidedef // 2275
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
+offsetx_mid = 0.0;
 }
 
 sidedef // 2276
@@ -44095,6 +45238,7 @@ sidedef // 2278
 sector = 335;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2279
@@ -44102,6 +45246,8 @@ sidedef // 2279
 sector = 353;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
+offsetx_mid = 64.0;
 }
 
 sidedef // 2280
@@ -44119,6 +45265,7 @@ sidedef // 2282
 {
 sector = 335;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2283
@@ -44126,6 +45273,7 @@ sidedef // 2283
 sector = 353;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2284
@@ -44137,6 +45285,7 @@ sidedef // 2285
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2286
@@ -44161,30 +45310,35 @@ sidedef // 2289
 {
 sector = 356;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2290
 {
 sector = 355;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2291
 {
 sector = 211;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2292
 {
 sector = 355;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2293
 {
 sector = 358;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2294
@@ -44192,6 +45346,7 @@ sidedef // 2294
 sector = 356;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2295
@@ -44199,18 +45354,21 @@ sidedef // 2295
 sector = 355;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2296
 {
 sector = 211;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2297
 {
 sector = 357;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2298
@@ -44218,6 +45376,7 @@ sidedef // 2298
 sector = 357;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2299
@@ -44235,6 +45394,7 @@ sidedef // 2301
 {
 sector = 357;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2302
@@ -44242,12 +45402,14 @@ sidedef // 2302
 sector = 357;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 2303
 {
 sector = 211;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 2304
@@ -44260,6 +45422,7 @@ sidedef // 2305
 sector = 211;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 2306
@@ -44277,6 +45440,7 @@ sidedef // 2308
 sector = 358;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2309
@@ -44294,6 +45458,7 @@ sidedef // 2311
 sector = 359;
 offsetx = -16;
 texturemiddle = "VRTEX4";
+offsetx_mid = 112.0;
 }
 
 sidedef // 2312
@@ -44301,6 +45466,8 @@ sidedef // 2312
 sector = 359;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = 0.0;
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2313
@@ -44313,6 +45480,7 @@ sidedef // 2314
 sector = 359;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 2315
@@ -44350,6 +45518,7 @@ sidedef // 2321
 sector = 360;
 offsetx = -48;
 texturemiddle = "VRTEX4";
+offsetx_mid = 80.0;
 }
 
 sidedef // 2322
@@ -44421,12 +45590,16 @@ sidedef // 2333
 sector = 349;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
+offsetx_mid = 32.0;
 }
 
 sidedef // 2334
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_mid = 0.0;
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2335
@@ -44439,6 +45612,7 @@ sidedef // 2336
 {
 sector = 364;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2337
@@ -44452,6 +45626,8 @@ sidedef // 2338
 sector = 338;
 offsetx = -96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
+offsetx_mid = 32.0;
 }
 
 sidedef // 2339
@@ -44463,7 +45639,6 @@ offsetx = 192;
 sidedef // 2340
 {
 sector = 337;
-offsetx = 32;
 texturemiddle = "VRTEX4";
 }
 
@@ -44472,6 +45647,7 @@ sidedef // 2341
 sector = 364;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2342
@@ -44494,6 +45670,7 @@ sidedef // 2345
 {
 sector = 365;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2346
@@ -44522,6 +45699,7 @@ sidedef // 2350
 sector = 211;
 offsetx = -64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 2351
@@ -44588,6 +45766,7 @@ sidedef // 2361
 sector = 368;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 2362
@@ -44616,6 +45795,7 @@ sidedef // 2366
 {
 sector = 365;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2367
@@ -44650,6 +45830,7 @@ sidedef // 2372
 {
 sector = 369;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2373
@@ -44679,6 +45860,7 @@ sidedef // 2377
 sector = 368;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 2378
@@ -44742,6 +45924,7 @@ sidedef // 2387
 {
 sector = 211;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2388
@@ -44795,6 +45978,7 @@ sidedef // 2397
 sector = 372;
 offsetx = 112;
 texturebottom = "VRTEX4";
+offsetx_bottom = 112.0;
 }
 
 sidedef // 2398
@@ -44838,6 +46022,7 @@ sidedef // 2405
 sector = 372;
 offsetx = 80;
 texturebottom = "VRTEX4";
+offsetx_bottom = 80.0;
 }
 
 sidedef // 2406
@@ -44871,6 +46056,7 @@ sidedef // 2411
 sector = 372;
 offsetx = 16;
 texturemiddle = "VRTEX4";
+offsetx_mid = 16.0;
 }
 
 sidedef // 2412
@@ -44878,6 +46064,7 @@ sidedef // 2412
 sector = 211;
 offsetx = 96;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 2413
@@ -44889,6 +46076,7 @@ sidedef // 2414
 {
 sector = 211;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2415
@@ -44902,6 +46090,7 @@ sidedef // 2416
 sector = 211;
 offsetx = 32;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 2417
@@ -44979,6 +46168,7 @@ sidedef // 2431
 sector = 373;
 offsetx = -64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2432
@@ -45021,6 +46211,7 @@ sidedef // 2439
 {
 sector = 373;
 offsetx = 432;
+offsetx_mid = -64.0;
 }
 
 sidedef // 2440
@@ -45064,6 +46255,7 @@ sidedef // 2447
 sector = 373;
 offsetx = 48;
 texturebottom = "VRTEX4";
+offsetx_bottom = 48.0;
 }
 
 sidedef // 2448
@@ -45076,6 +46268,7 @@ sidedef // 2449
 {
 sector = 211;
 offsetx = 448;
+offsetx_mid = -48.0;
 }
 
 sidedef // 2450
@@ -45089,6 +46282,7 @@ sidedef // 2451
 sector = 211;
 offsetx = -48;
 texturebottom = "VRTEX4";
+offsetx_bottom = 80.0;
 }
 
 sidedef // 2452
@@ -45102,6 +46296,7 @@ sidedef // 2453
 sector = 211;
 offsetx = 64;
 texturebottom = "VRTEX4";
+offsetx_bottom = 64.0;
 }
 
 sidedef // 2454
@@ -45184,6 +46379,7 @@ sidedef // 2469
 sector = 374;
 offsetx = 400;
 texturemiddle = "VRTEX4";
+offsetx_mid = 16.0;
 }
 
 sidedef // 2470
@@ -45221,6 +46417,7 @@ sidedef // 2476
 sector = 374;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 2477
@@ -45228,6 +46425,7 @@ sidedef // 2477
 sector = 211;
 offsetx = 80;
 texturemiddle = "VRTEX4";
+offsetx_mid = 80.0;
 }
 
 sidedef // 2478
@@ -45235,6 +46433,7 @@ sidedef // 2478
 sector = 211;
 offsetx = 416;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 2479
@@ -45289,6 +46488,7 @@ sidedef // 2487
 sector = 0;
 offsetx = 128;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 2488
@@ -45300,6 +46500,7 @@ sidedef // 2489
 {
 sector = 0;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 2490
@@ -45318,18 +46519,21 @@ sidedef // 2492
 {
 sector = 398;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2493
 {
 sector = 398;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2494
 {
 sector = 400;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2495
@@ -45387,18 +46591,21 @@ sidedef // 2505
 {
 sector = 382;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2506
 {
 sector = 381;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2507
 {
 sector = 211;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2508
@@ -45406,6 +46613,7 @@ sidedef // 2508
 sector = 211;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX3";
+offsetx_top = 0.0;
 }
 
 sidedef // 2509
@@ -45418,36 +46626,42 @@ sidedef // 2510
 {
 sector = 211;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2511
 {
 sector = 382;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2512
 {
 sector = 211;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2513
 {
 sector = 383;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2514
 {
 sector = 381;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2515
 {
 sector = 211;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 2516
@@ -45459,12 +46673,14 @@ sidedef // 2517
 {
 sector = 381;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2518
 {
 sector = 382;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2519
@@ -45472,6 +46688,7 @@ sidedef // 2519
 sector = 211;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX3";
+offsetx_top = 0.0;
 }
 
 sidedef // 2520
@@ -45483,6 +46700,7 @@ sidedef // 2521
 {
 sector = 381;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2522
@@ -45490,6 +46708,7 @@ sidedef // 2522
 sector = 381;
 offsetx = 192;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 2523
@@ -45508,6 +46727,7 @@ sidedef // 2525
 sector = 381;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2526
@@ -45526,6 +46746,7 @@ sidedef // 2528
 sector = 382;
 offsetx = 128;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2529
@@ -45545,6 +46766,7 @@ sidedef // 2531
 sector = 381;
 offsetx = 16;
 texturemiddle = "VRTEX4";
+offsetx_mid = 16.0;
 }
 
 sidedef // 2532
@@ -45552,6 +46774,7 @@ sidedef // 2532
 sector = 383;
 offsetx = 240;
 texturemiddle = "VRTEX4";
+offsetx_mid = 112.0;
 }
 
 sidedef // 2533
@@ -45560,6 +46783,7 @@ sector = 384;
 offsetx = 24;
 offsety = 2;
 texturemiddle = "VRTEX4";
+offsetx_mid = 24.0;
 }
 
 sidedef // 2534
@@ -45568,6 +46792,8 @@ sector = 381;
 offsetx = 24;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = 24.0;
+offsetx_bottom = 24.0;
 }
 
 sidedef // 2535
@@ -45581,6 +46807,7 @@ sector = 384;
 offsetx = 32;
 offsety = 2;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 2537
@@ -45596,6 +46823,7 @@ sidedef // 2538
 sector = 381;
 offsetx = 40;
 texturemiddle = "VRTEX4";
+offsetx_mid = 40.0;
 }
 
 sidedef // 2539
@@ -45801,6 +47029,7 @@ sidedef // 2575
 sector = 400;
 offsetx = 184;
 texturemiddle = "VRTEX4";
+offsetx_mid = -72.0;
 }
 
 sidedef // 2576
@@ -46034,6 +47263,7 @@ sidedef // 2618
 sector = 398;
 offsetx = 8;
 texturemiddle = "VRTEX4";
+offsetx_mid = -120.0;
 }
 
 sidedef // 2619
@@ -46067,6 +47297,7 @@ sidedef // 2623
 sector = 0;
 offsetx = 304;
 texturemiddle = "VRTEX4";
+offsetx_mid = -48.0;
 }
 
 sidedef // 2624
@@ -46104,6 +47335,7 @@ sidedef // 2629
 {
 sector = 401;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2630
@@ -46115,6 +47347,7 @@ sidedef // 2631
 {
 sector = 401;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2632
@@ -46126,18 +47359,21 @@ sidedef // 2633
 {
 sector = 401;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2634
 {
 sector = 401;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2635
 {
 sector = 211;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2636
@@ -46149,6 +47385,7 @@ sidedef // 2637
 {
 sector = 402;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2638
@@ -46160,6 +47397,7 @@ sidedef // 2639
 {
 sector = 402;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2640
@@ -46171,12 +47409,14 @@ sidedef // 2641
 {
 sector = 402;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2642
 {
 sector = 402;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 2643
@@ -46189,30 +47429,35 @@ sidedef // 2644
 {
 sector = 401;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2645
 {
 sector = 403;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2646
 {
 sector = 403;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2647
 {
 sector = 403;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2648
 {
 sector = 404;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2649
@@ -46224,6 +47469,7 @@ sidedef // 2650
 {
 sector = 402;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 2651
@@ -46237,6 +47483,7 @@ sidedef // 2652
 {
 sector = 404;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2653
@@ -46258,6 +47505,7 @@ sidedef // 2656
 {
 sector = 402;
 texturetop = "VRTEX4";
+offsetx_top = 0.0;
 }
 
 sidedef // 2657
@@ -46270,24 +47518,28 @@ sidedef // 2658
 sector = 403;
 offsetx = 192;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 2659
 {
 sector = 405;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2660
 {
 sector = 405;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2661
 {
 sector = 405;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2662
@@ -46353,6 +47605,7 @@ sidedef // 2672
 sector = 398;
 offsetx = 144;
 texturemiddle = "VRTEX4";
+offsetx_mid = -16.0;
 }
 
 sidedef // 2673
@@ -46428,6 +47681,7 @@ sector = 125;
 sidedef // 2685
 {
 sector = 121;
+offsetx_mid = 0.0;
 }
 
 sidedef // 2686
@@ -46435,6 +47689,7 @@ sidedef // 2686
 sector = 125;
 offsetx = 704;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2687
@@ -46445,6 +47700,7 @@ sector = 125;
 sidedef // 2688
 {
 sector = 121;
+offsetx_mid = 0.0;
 }
 
 sidedef // 2689
@@ -46452,6 +47708,7 @@ sidedef // 2689
 sector = 121;
 offsetx = 1088;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2690
@@ -46459,18 +47716,21 @@ sidedef // 2690
 sector = 410;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2691
 {
 sector = 143;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2692
 {
 sector = 143;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2693
@@ -46490,6 +47750,7 @@ sidedef // 2695
 sector = 410;
 offsetx = 96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 2696
@@ -46497,6 +47758,7 @@ sidedef // 2696
 sector = 410;
 offsetx = 256;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2697
@@ -46516,6 +47778,7 @@ sidedef // 2699
 sector = 410;
 offsetx = 216;
 texturemiddle = "VRTEX4";
+offsetx_mid = -40.0;
 }
 
 sidedef // 2700
@@ -46523,6 +47786,7 @@ sidedef // 2700
 sector = 410;
 offsetx = 104;
 texturemiddle = "VRTEX4";
+offsetx_mid = -24.0;
 }
 
 sidedef // 2701
@@ -46542,6 +47806,7 @@ sidedef // 2703
 sector = 410;
 offsetx = 208;
 texturemiddle = "VRTEX4";
+offsetx_mid = -48.0;
 }
 
 sidedef // 2704
@@ -46549,6 +47814,7 @@ sidedef // 2704
 sector = 410;
 offsetx = 112;
 texturemiddle = "VRTEX4";
+offsetx_mid = -16.0;
 }
 
 sidedef // 2705
@@ -46568,6 +47834,7 @@ sidedef // 2707
 sector = 410;
 offsetx = 200;
 texturemiddle = "VRTEX4";
+offsetx_mid = -56.0;
 }
 
 sidedef // 2708
@@ -46575,6 +47842,7 @@ sidedef // 2708
 sector = 410;
 offsetx = 120;
 texturemiddle = "VRTEX4";
+offsetx_mid = -8.0;
 }
 
 sidedef // 2709
@@ -46630,6 +47898,7 @@ sidedef // 2717
 sector = 410;
 offsetx = 192;
 texturemiddle = "VRTEX4";
+offsetx_mid = -64.0;
 }
 
 sidedef // 2718
@@ -46637,6 +47906,7 @@ sidedef // 2718
 sector = 410;
 offsetx = 184;
 texturemiddle = "VRTEX4";
+offsetx_mid = -72.0;
 }
 
 sidedef // 2719
@@ -46644,6 +47914,7 @@ sidedef // 2719
 sector = 412;
 offsetx = 176;
 texturemiddle = "VRTEX4";
+offsetx_mid = -80.0;
 }
 
 sidedef // 2720
@@ -46651,6 +47922,7 @@ sidedef // 2720
 sector = 410;
 offsetx = 168;
 texturemiddle = "VRTEX4";
+offsetx_mid = -88.0;
 }
 
 sidedef // 2721
@@ -46658,6 +47930,7 @@ sidedef // 2721
 sector = 410;
 offsetx = 128;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2722
@@ -46665,6 +47938,7 @@ sidedef // 2722
 sector = 412;
 offsetx = 136;
 texturemiddle = "VRTEX4";
+offsetx_mid = -120.0;
 }
 
 sidedef // 2723
@@ -46672,6 +47946,7 @@ sidedef // 2723
 sector = 410;
 offsetx = 144;
 texturemiddle = "VRTEX4";
+offsetx_mid = -112.0;
 }
 
 sidedef // 2724
@@ -46679,6 +47954,7 @@ sidedef // 2724
 sector = 410;
 offsetx = 152;
 texturemiddle = "VRTEX4";
+offsetx_mid = -104.0;
 }
 
 sidedef // 2725
@@ -46734,6 +48010,7 @@ sidedef // 2733
 sector = 410;
 offsetx = 160;
 texturemiddle = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 2734
@@ -46741,6 +48018,7 @@ sidedef // 2734
 sector = 410;
 offsetx = 152;
 texturemiddle = "VRTEX4";
+offsetx_mid = -104.0;
 }
 
 sidedef // 2735
@@ -46748,6 +48026,7 @@ sidedef // 2735
 sector = 410;
 offsetx = 144;
 texturemiddle = "VRTEX4";
+offsetx_mid = -112.0;
 }
 
 sidedef // 2736
@@ -46755,6 +48034,7 @@ sidedef // 2736
 sector = 410;
 offsetx = 136;
 texturemiddle = "VRTEX4";
+offsetx_mid = -120.0;
 }
 
 sidedef // 2737
@@ -46762,6 +48042,7 @@ sidedef // 2737
 sector = 410;
 offsetx = 160;
 texturemiddle = "VRTEX4";
+offsetx_mid = -96.0;
 }
 
 sidedef // 2738
@@ -46780,6 +48061,7 @@ sidedef // 2740
 sector = 411;
 offsetx = 72;
 texturemiddle = "VRTEX4";
+offsetx_mid = 72.0;
 }
 
 sidedef // 2741
@@ -46787,6 +48069,7 @@ sidedef // 2741
 sector = 399;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 2742
@@ -46794,6 +48077,7 @@ sidedef // 2742
 sector = 411;
 offsetx = 80;
 texturemiddle = "VRTEX4";
+offsetx_mid = 80.0;
 }
 
 sidedef // 2743
@@ -46801,6 +48085,7 @@ sidedef // 2743
 sector = 411;
 offsetx = 32;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 2744
@@ -46808,6 +48093,7 @@ sidedef // 2744
 sector = 399;
 offsetx = 64;
 texturemiddle = "VRTEX4";
+offsetx_mid = 64.0;
 }
 
 sidedef // 2745
@@ -46815,6 +48101,7 @@ sidedef // 2745
 sector = 399;
 offsetx = 56;
 texturemiddle = "VRTEX4";
+offsetx_mid = 56.0;
 }
 
 sidedef // 2746
@@ -46834,12 +48121,14 @@ sidedef // 2748
 sector = 411;
 offsetx = 24;
 texturemiddle = "VRTEX4";
+offsetx_mid = 24.0;
 }
 
 sidedef // 2749
 {
 sector = 411;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2750
@@ -46859,6 +48148,7 @@ sidedef // 2752
 sector = 411;
 offsetx = 96;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 2753
@@ -46866,6 +48156,7 @@ sidedef // 2753
 sector = 411;
 offsetx = 16;
 texturemiddle = "VRTEX4";
+offsetx_mid = 16.0;
 }
 
 sidedef // 2754
@@ -46885,6 +48176,7 @@ sidedef // 2756
 sector = 411;
 offsetx = 104;
 texturemiddle = "VRTEX4";
+offsetx_mid = -24.0;
 }
 
 sidedef // 2757
@@ -46892,6 +48184,7 @@ sidedef // 2757
 sector = 411;
 offsetx = 8;
 texturemiddle = "VRTEX4";
+offsetx_mid = 8.0;
 }
 
 sidedef // 2758
@@ -46911,12 +48204,14 @@ sidedef // 2760
 sector = 411;
 offsetx = 112;
 texturemiddle = "VRTEX4";
+offsetx_mid = -16.0;
 }
 
 sidedef // 2761
 {
 sector = 411;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2762
@@ -46972,12 +48267,14 @@ sidedef // 2770
 sector = 411;
 offsetx = 120;
 texturemiddle = "VRTEX4";
+offsetx_mid = -8.0;
 }
 
 sidedef // 2771
 {
 sector = 411;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2772
@@ -46985,6 +48282,7 @@ sidedef // 2772
 sector = 411;
 offsetx = 8;
 texturemiddle = "VRTEX4";
+offsetx_mid = 8.0;
 }
 
 sidedef // 2773
@@ -46992,6 +48290,7 @@ sidedef // 2773
 sector = 411;
 offsetx = 16;
 texturemiddle = "VRTEX4";
+offsetx_mid = 16.0;
 }
 
 sidedef // 2774
@@ -46999,6 +48298,7 @@ sidedef // 2774
 sector = 411;
 offsetx = 120;
 texturemiddle = "VRTEX4";
+offsetx_mid = 120.0;
 }
 
 sidedef // 2775
@@ -47006,6 +48306,7 @@ sidedef // 2775
 sector = 411;
 offsetx = 112;
 texturemiddle = "VRTEX4";
+offsetx_mid = 112.0;
 }
 
 sidedef // 2776
@@ -47013,6 +48314,7 @@ sidedef // 2776
 sector = 411;
 offsetx = 104;
 texturemiddle = "VRTEX4";
+offsetx_mid = 104.0;
 }
 
 sidedef // 2777
@@ -47020,6 +48322,7 @@ sidedef // 2777
 sector = 411;
 offsetx = 96;
 texturemiddle = "VRTEX4";
+offsetx_mid = 96.0;
 }
 
 sidedef // 2778
@@ -47075,6 +48378,7 @@ sidedef // 2786
 sector = 411;
 offsetx = 24;
 texturemiddle = "VRTEX4";
+offsetx_mid = 24.0;
 }
 
 sidedef // 2787
@@ -47082,6 +48386,7 @@ sidedef // 2787
 sector = 411;
 offsetx = 32;
 texturemiddle = "VRTEX4";
+offsetx_mid = 32.0;
 }
 
 sidedef // 2788
@@ -47089,6 +48394,7 @@ sidedef // 2788
 sector = 411;
 offsetx = 40;
 texturemiddle = "VRTEX4";
+offsetx_mid = 40.0;
 }
 
 sidedef // 2789
@@ -47096,6 +48402,7 @@ sidedef // 2789
 sector = 411;
 offsetx = 48;
 texturemiddle = "VRTEX4";
+offsetx_mid = 48.0;
 }
 
 sidedef // 2790
@@ -47103,12 +48410,14 @@ sidedef // 2790
 sector = 411;
 offsetx = 88;
 texturemiddle = "VRTEX4";
+offsetx_mid = 88.0;
 }
 
 sidedef // 2791
 {
 sector = 326;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2792
@@ -47136,6 +48445,7 @@ sidedef // 2796
 sector = 413;
 offsety = -8;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2797
@@ -47149,6 +48459,7 @@ sidedef // 2798
 sector = 413;
 offsety = -8;
 texturemiddle = "VRTEX4";
+offsetx_mid = -16.0;
 }
 
 sidedef // 2799
@@ -47162,12 +48473,15 @@ sidedef // 2800
 sector = 413;
 texturetop = "VRTEX4";
 texturebottom = "VRTEX4";
+offsetx_top = 0.0;
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2801
 {
 sector = 325;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2802
@@ -47623,6 +48937,7 @@ sidedef // 2876
 sector = 213;
 offsetx = 768;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
 }
 
 sidedef // 2877
@@ -47636,6 +48951,7 @@ sidedef // 2878
 sector = 213;
 offsetx = 704;
 texturebottom = "VRTEX4";
+offsetx_bottom = -28.0;
 }
 
 sidedef // 2879
@@ -47649,6 +48965,7 @@ sidedef // 2880
 sector = 399;
 offsetx = 512;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2881
@@ -47656,6 +48973,7 @@ sidedef // 2881
 sector = 399;
 offsetx = 128;
 texturemiddle = "VRTEX4";
+offsetx_mid = 0.0;
 }
 
 sidedef // 2882
@@ -47663,6 +48981,7 @@ sidedef // 2882
 sector = 143;
 offsetx = 224;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 2883
@@ -47670,6 +48989,7 @@ sidedef // 2883
 sector = 143;
 offsetx = 480;
 texturemiddle = "VRTEX4";
+offsetx_mid = -32.0;
 }
 
 sidedef // 2884
@@ -47798,6 +49118,7 @@ sidedef // 2906
 sector = 353;
 offsetx = 256;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2907
@@ -47810,6 +49131,7 @@ sidedef // 2908
 sector = 353;
 offsetx = 128;
 texturebottom = "VRTEX4";
+offsetx_bottom = 0.0;
 }
 
 sidedef // 2909
@@ -47834,6 +49156,7 @@ sidedef // 2912
 sector = 421;
 offsetx = 184;
 texturebottom = "VRTEX4";
+offsetx_bottom = 56.0;
 }
 
 sidedef // 2913
@@ -47847,6 +49170,7 @@ sidedef // 2914
 sector = 353;
 offsetx = 224;
 texturebottom = "VRTEX4";
+offsetx_bottom = 96.0;
 }
 
 sidedef // 2915
@@ -47860,6 +49184,7 @@ sidedef // 2916
 sector = 422;
 offsetx = 200;
 texturebottom = "VRTEX4";
+offsetx_bottom = 72.0;
 }
 
 sidedef // 2917
@@ -47914,6 +49239,7 @@ sidedef // 2926
 sector = 422;
 offsetx = 160;
 texturebottom = "VRTEX4";
+offsetx_bottom = 32.0;
 }
 
 sidedef // 2927

--- a/src/ZombieHorde2Legacy/textures.mappack.ze11
+++ b/src/ZombieHorde2Legacy/textures.mappack.ze11
@@ -1,0 +1,41 @@
+Texture "VRTEX1", 256, 256
+{
+	XScale 2
+	YScale 2
+	Patch "VRTEX1", 0, 0
+}
+
+Texture "VRTEX2", 192, 192
+{
+	XScale 3
+	YScale 3
+	Patch "VRTEX2", 0, 0
+}
+
+Texture "VRTEX3", 192, 192
+{
+	XScale 3
+	YScale 3
+	Patch "VRTEX3", 0, 0
+}
+
+Texture "VRTEX4", 128, 256
+{
+	XScale 2
+	YScale 2
+	Patch "VRTEX4", 0, 0
+}
+
+Texture "VRTEX5", 320, 320
+{
+	XScale 2.5
+	YScale 2.5
+	Patch "VRTEX5", 0, 0
+}
+
+Texture "VRTEX6", 320, 320
+{
+	XScale 2.5
+	YScale 2.5
+	Patch "VRTEX6", 0, 0
+}


### PR DESCRIPTION
Added the correct scaling for VRTEX textures.

ZE11: Apparently, most of VRTEX2 were misaligned on this map after conversion.
ZM07: Somehow, many VERTX2 & 4 were misaligned.
This aims to align them and have proper visuals.