### PR TITLE
Various API changes and function renames

### DIFF
--- a/src/ZombieHorde2/acs_source/zh2game/admin/admin.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/admin/admin.acs
@@ -11,15 +11,15 @@
 
 strict namespace Admin
 {
-    internal bool GetAdmin() { return GetPlayerAdmin(PlayerNumber()); }
-    internal bool GetPlayerAdmin(int id)
+    internal bool GetIsAdmin() { return GetPlayerIsAdmin(PlayerNumber()); }
+    internal bool GetPlayerIsAdmin(int id)
     {
         VALIDATE_ID_VALID_FUNCTION_RETURN(id, false);
         return ZH2Game::PersistingGameContext.Players[id].IsAdmin;
     }
 
-    internal void SetAdmin(bool set) { SetPlayerAdmin(PlayerNumber(), set); }
-    internal void SetPlayerAdmin(int id, bool set)
+    internal void SetIsAdmin(bool set) { SetPlayerIsAdmin(PlayerNumber(), set); }
+    internal void SetPlayerIsAdmin(int id, bool set)
     {
         VALIDATE_ID_VALID_FUNCTION(id);
 
@@ -33,8 +33,13 @@ strict namespace Admin
         Logger::LogDebug(LogSource, "Player (\cd" + str(id) + "\cj) " + BCSUTILS::PlayerName(id) + " has been \cd" + (set ? "added" : "removed") + "\cj as an admin.");
     }
 
+    internal void BroadcastAdmin(bool set)
+    {
+        BroadcastPlayerAdmin(PlayerNumber(), set);
+    }
+
     // General broadcast function to inform everybody somebody was set/unset as an admin.
-    internal void BroadcastAdmin(int id, bool set)
+    internal void BroadcastPlayerAdmin(int id, bool set)
     {
         str logMessage;
         buildmsg(logMessage = StrParam())
@@ -64,7 +69,7 @@ strict namespace Admin
         if (Round::GetActiveKnownRoundState() >= Round::STATEENDING)
             return;
 
-        if (!Admin::GetAdmin())
+        if (!Admin::GetIsAdmin())
         {
             Logger::LogActivator("You must be an admin for this operation.");
             return;
@@ -73,7 +78,7 @@ strict namespace Admin
         // If we enable the admin menu, make sure the settings hud is disabled.
         ZH2Game::GameContext.HasClientSettingsHudOpen = false;
 
-        SetAdminHudEnabledInternal(true);
+        SetIsAdminHudEnabledInternal(true);
     }
 
     internal void DisableAdminHud()
@@ -82,10 +87,10 @@ strict namespace Admin
         // Also reset the target player id if we had somebody.
         Hud::ResetHud();
 
-        SetAdminHudEnabledInternal(false);
+        SetIsAdminHudEnabledInternal(false);
     }
 
-    internal void SetAdminHudEnabledInternal(bool set)
+    internal void SetIsAdminHudEnabledInternal(bool set)
     {
         ZH2Game::GameContext.HasAdminHudOpen = set;
         Hud::SetCursorEnabled(set);

--- a/src/ZombieHorde2/acs_source/zh2game/admin/hudactions.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/admin/hudactions.acs
@@ -324,7 +324,7 @@ strict namespace Admin
         }
     }
 
-    internal void AdminIncrementSpecieItemClientside(Player::SpecieTypeT specie, int itemIndex, int amount)
+    internal void AdminIncrementSpecieItemClientside(Player::PlayerSpecieT specie, int itemIndex, int amount)
     {
         if (!NamedRequestScriptPuke("zh2_internal_menu_increment_item_specie", specie, itemIndex, amount))
             Logger::LogError(LogSource, "Failed to call admin increment specie item.");
@@ -344,7 +344,7 @@ strict namespace Admin
         // For now only allow giving or taking one item.
         amount = BCSUtils::Sgn(amount);
 
-        Player::SpecieTypeT specie = Player::GetSpecieTypeByIndex(specieIndex);
+        Player::PlayerSpecieT specie = Player::GetSpecieTypeByIndex(specieIndex);
 
         str name = Item::GetItemName(itemIndex);
         str label = Item::GetItemLabel(itemIndex);
@@ -397,7 +397,7 @@ strict namespace Admin
         Logger::LogBold("An \cfadmin\cj has given reward \cd" + name + "\cj to \cf" + BCSUtils::PlayerName(playerId) + "\cj!");
     }
 
-    internal void AdminGiveSpecieRewardClientside(Player::SpecieTypeT specie, int rewardIndex)
+    internal void AdminGiveSpecieRewardClientside(Player::PlayerSpecieT specie, int rewardIndex)
     {
         if (!NamedRequestScriptPuke("zh2_internal_menu_give_reward_specie", specie, rewardIndex))
             Logger::LogError(LogSource, "Failed to call admin give specie reward.");
@@ -413,7 +413,7 @@ strict namespace Admin
         if (rewardIndex < 0 || rewardIndex >= Reward::GetRewardCollectionSize())
             terminate;
 
-        Player::SpecieTypeT specie = Player::GetSpecieTypeByIndex(specieIndex);
+        Player::PlayerSpecieT specie = Player::GetSpecieTypeByIndex(specieIndex);
         ITERATESPECIES(specie, {
             Reward::GivePlayerRewardByIndex(id, rewardIndex);
         });
@@ -443,7 +443,7 @@ strict namespace Admin
         Logger::LogBold("An \cfadmin\cj has added power \cd" + Power::GetPowerIndexAsString(powerIndex) + "\cj to " + BCSUtils::PlayerName(playerId) + "\cj!");
     }
 
-    internal void AdminIncrementSpeciePowerClientside(Player::SpecieTypeT specie, int powerIndex, int tics)
+    internal void AdminIncrementSpeciePowerClientside(Player::PlayerSpecieT specie, int powerIndex, int tics)
     {
         if (!NamedRequestScriptPuke("zh2_internal_menu_increment_power_specie", specie, powerIndex, tics))
             Logger::LogError(LogSource, "Failed to call admin increment specie power.");
@@ -460,7 +460,7 @@ strict namespace Admin
         // For now only allow incrementing
         if (tics <= 0) terminate;
 
-        Player::SpecieTypeT specie = Player::GetSpecieTypeByIndex(specieIndex);
+        Player::PlayerSpecieT specie = Player::GetSpecieTypeByIndex(specieIndex);
         ITERATESPECIES(specie, {
             Power::AddPlayerPowerTics(id, powerIndex, tics);
         });
@@ -491,7 +491,7 @@ strict namespace Admin
         else            Logger::LogBold("An \cfadmin\cj has taken \cd" + str(amountNormalized) + "\cj points of kevlar armor from " + BCSUtils::PlayerName(playerId) + "\cj!");
     }
 
-    internal void AdminIncrementSpecieArmorClientSide(Player::SpecieTypeT specie, int amount)
+    internal void AdminIncrementSpecieArmorClientSide(Player::PlayerSpecieT specie, int amount)
     {
         if (!NamedRequestScriptPuke("zh2_internal_menu_increment_armor_specie", specie, amount))
             Logger::LogError(LogSource, "Failed to call admin increment player armor on specie.");
@@ -506,7 +506,7 @@ strict namespace Admin
 
         if (amount == 0) terminate;
 
-        Player::SpecieTypeT specie = Player::GetSpecieTypeByIndex(specieIndex);
+        Player::PlayerSpecieT specie = Player::GetSpecieTypeByIndex(specieIndex);
         ITERATESPECIES(specie, {
             Player::AddPlayerKevlarPoints(id, amount);
         });
@@ -521,7 +521,7 @@ strict namespace Admin
     }
 
     // Rewards (for everybody or specie specific)
-    internal void AdminGiveRewardContainerSpecieClientSide(Player::SpecieTypeT specie, Reward::RewardItemTypeFlagsT type)
+    internal void AdminGiveRewardContainerSpecieClientSide(Player::PlayerSpecieT specie, Reward::RewardItemTypeFlagsT type)
     {
         if (!NamedRequestScriptPuke("zh2_internal_menu_give_container_specie", specie, type))
             Logger::LogError(LogSource, "Failed to call admin give reward container specie.");
@@ -535,7 +535,7 @@ strict namespace Admin
         int typeInt = (int)typeRaw;
         int index = BCSUtils::Flag2Index(typeInt) + 1;
 
-        Player::SpecieTypeT specie = Player::GetSpecieTypeByIndex(specieIndex);
+        Player::PlayerSpecieT specie = Player::GetSpecieTypeByIndex(specieIndex);
         Reward::RewardItemTypeFlagsT type = Reward::GetRewardItemTypeByIndex(index);
         if (type == Reward::REWARDNONE) terminate;
 

--- a/src/ZombieHorde2/acs_source/zh2game/admin/hudactions.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/admin/hudactions.acs
@@ -14,7 +14,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_action_infect" (int id) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         VALIDATE_ID_VALID_SCRIPT(id);
         if (Player::GetPlayerIsZombie(id)) terminate;
 
@@ -36,7 +36,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_action_cure" (int id) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         VALIDATE_ID_VALID_SCRIPT(id);
         if (Player::GetPlayerIsHuman(id)) terminate;
 
@@ -57,7 +57,7 @@ strict namespace Admin
     {
         int index = RoundTimer::GetActiveTimerIndex();
 
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         if (!RoundTimer::GetTimerDefined(index)) terminate;
 
         int ticDiff = RoundTimer::IncrementTimer(index, addTics);
@@ -81,7 +81,7 @@ strict namespace Admin
     {
         int index = RoundTimer::GetActiveTimerIndex();
 
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         if (!RoundTimer::GetTimerDefined(index)) terminate;
         if (RoundTimer::GetTimerPaused(index)) terminate;
 
@@ -101,7 +101,7 @@ strict namespace Admin
     {
         int index = RoundTimer::GetActiveTimerIndex();
 
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         if (!RoundTimer::GetTimerDefined(index)) terminate;
         if (!RoundTimer::GetTimerPaused(index)) terminate;
 
@@ -119,7 +119,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_action_kill_unsafe_players" (int addTics) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         if (Round::GetActiveKnownRoundState() != Round::STATEPLAYING) terminate;
 
         Game::KillUnsafePlayers();
@@ -134,7 +134,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_action_kill" (int id) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         VALIDATE_ID_VALID_SCRIPT(id);
         if (!BCSUtils::ActorIsAlive(Identity::GetTID(id))) terminate;
 
@@ -150,7 +150,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_set_round_state" (int index) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
 
         // Explicit check against index 0, which means the round state is disabled.
         if (index == 0)
@@ -174,7 +174,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_set_round_timer" (int index) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
 
         // Explicit check against index 0, which means the round timer is disabled.
         if (index == 0)
@@ -198,7 +198,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_add_human_bot" net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         if (BCSUtils::ClientCount() == BCSUtils::MAX_PLAYERS) terminate;
 
         // Force next joining player (so the bot) to be a zombie.
@@ -218,7 +218,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_add_zombie_bot" net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         if (BCSUtils::ClientCount() == BCSUtils::MAX_PLAYERS) terminate;
 
         // Force next joining player (so the bot) to be a zombie.
@@ -238,7 +238,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_remove_bot" net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         if (BCSUtils::BotCount() == 0) terminate;
         RemoveBot();
     }
@@ -251,7 +251,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_start_resist" (int index) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         if (Resist::IsActive(index)) terminate;
         Resist::StartResist(index);
     }
@@ -264,7 +264,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_stop_resist" (int index) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         if (!Resist::IsActive(index)) terminate;
         Resist::StopResist(index);
     }
@@ -277,7 +277,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_end_game" net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         if (Round::GetActiveKnownRoundState() != Round::STATEPLAYING) terminate;
         Game::SetWinningSpecie(Game::SPECIETIE);
         Game::SetEndReason(Game::REASONADMINENDED);
@@ -292,7 +292,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_increment_item" (raw playerIdRaw, raw itemIndexRaw, int amountRaw) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
 
         int playerId = (int)playerIdRaw;
         int itemIndex = (int)itemIndexRaw;
@@ -332,7 +332,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_increment_item_specie" (raw specieIndexRaw, raw itemIndexRaw, raw amountRaw) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
 
         int specieIndex = (int)specieIndexRaw;
         int itemIndex = (int)itemIndexRaw;
@@ -379,7 +379,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_give_reward_player" (raw playerIdRaw, raw rewardIndexRaw) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
 
         int playerId = (int)playerIdRaw;
         int rewardIndex = (int)rewardIndexRaw;
@@ -405,7 +405,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_give_reward_specie" (raw specieIndexRaw, raw rewardIndexRaw) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
 
         int specieIndex = (int)specieIndexRaw;
         int rewardIndex = (int)rewardIndexRaw;
@@ -436,7 +436,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_increment_power" (int playerId, int powerIndex, int tics) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         VALIDATE_ID_VALID_SCRIPT(playerId);
 
         Power::AddPlayerPowerTics(playerId, powerIndex, tics);
@@ -451,7 +451,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_increment_power_specie" (raw specieIndexRaw, raw powerIndexRaw, raw ticsRaw) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
 
         int specieIndex = (int)specieIndexRaw;
         int powerIndex = (int)powerIndexRaw;
@@ -480,7 +480,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_increment_armor" (int playerId, int amount) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
         if (amount == 0) terminate;
         VALIDATE_ID_VALID_SCRIPT(playerId);
 
@@ -499,7 +499,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_increment_armor_specie"  (raw specieIndexRaw, raw amountRaw) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
 
         int specieIndex = (int)specieIndexRaw;
         int amount = (int)amountRaw;
@@ -529,7 +529,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_give_container_specie" (raw specieIndexRaw, raw typeRaw) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
 
         int specieIndex = (int)specieIndexRaw;
         int typeInt = (int)typeRaw;
@@ -558,7 +558,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_give_container_player" (raw playerIdRaw, raw typeRaw) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
 
         int playerId = (int)playerIdRaw;
         int typeInt = (int)typeRaw;
@@ -583,7 +583,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_set_allow_join" (raw allowRaw) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
 
         bool allow = (bool)allowRaw;
         ZH2Game::GameContext.AlwaysAllowJoin = allow;
@@ -598,7 +598,7 @@ strict namespace Admin
 
     script "zh2_internal_menu_set_player_allow_join" (raw playerIdRaw, raw allowRaw) net
     {
-        if (!GetAdmin()) terminate;
+        if (!GetIsAdmin()) terminate;
 
         int playerId = (int)playerIdRaw;
         bool allow = (bool)allowRaw;

--- a/src/ZombieHorde2/acs_source/zh2game/admin/rcon.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/admin/rcon.acs
@@ -8,12 +8,12 @@ strict namespace Admin
 {
     // Callable from the rcon.
 
-    script "zh2_enableadminplayer" (int id)
+    script "zh2_admin_playerenable" (int id)
     {
         RconSetPlayerIsAdmin(id, true);
     }
 
-    script "zh2_disableadminplayer" (int id)
+    script "zh2_admin_playerdisable" (int id)
     {
         RconSetPlayerIsAdmin(id, false);
     }

--- a/src/ZombieHorde2/acs_source/zh2game/admin/rcon.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/admin/rcon.acs
@@ -18,6 +18,11 @@ strict namespace Admin
         RconSetPlayerIsAdmin(id, false);
     }
 
+    internal void RconSetIsAdmin(bool set)
+    {
+        RconSetPlayerIsAdmin(PlayerNumber(), set);
+    }
+
     internal void RconSetPlayerIsAdmin(int id, bool set)
     {
         if (!Identity::IsValidID(id))

--- a/src/ZombieHorde2/acs_source/zh2game/admin/rcon.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/admin/rcon.acs
@@ -10,15 +10,15 @@ strict namespace Admin
 
     script "zh2_enableadminplayer" (int id)
     {
-        RconSetPlayerAdmin(id, true);
+        RconSetPlayerIsAdmin(id, true);
     }
 
     script "zh2_disableadminplayer" (int id)
     {
-        RconSetPlayerAdmin(id, false);
+        RconSetPlayerIsAdmin(id, false);
     }
 
-    internal void RconSetPlayerAdmin(int id, bool set)
+    internal void RconSetPlayerIsAdmin(int id, bool set)
     {
         if (!Identity::IsValidID(id))
             return;
@@ -27,10 +27,10 @@ strict namespace Admin
             return;
 
         // Just ignore if we try to enable/disable on somebody that already has admin set to the same state.
-        if (GetPlayerAdmin(id) == set) return;
+        if (GetPlayerIsAdmin(id) == set) return;
 
-        SetPlayerAdmin(id, set);
-        BroadcastAdmin(id, set);
+        SetPlayerIsAdmin(id, set);
+        BroadcastPlayerAdmin(id, set);
 
         Sync::SyncAdmins();
     }

--- a/src/ZombieHorde2/acs_source/zh2game/binds.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/binds.acs
@@ -11,7 +11,7 @@ strict namespace ZH2Game
     {
         // Set the timer to be 1 second left if a timer is active and we either play offline, or the user is an admin.
         // Do not check for development, for now.
-        if (/*IsDevelopment() &&*/ RoundTimer::GetAnyTimerActive() && (!IsNetworkGame() || Admin::GetAdmin()))
+        if (/*IsDevelopment() &&*/ RoundTimer::GetAnyTimerActive() && (!IsNetworkGame() || Admin::GetIsAdmin()))
         {
             int index = RoundTimer::GetActiveTimerIndex();
 
@@ -142,12 +142,12 @@ strict namespace ZH2Game
             terminate;
         }
 
-        Admin::RconSetPlayerAdmin(PlayerNumber(), true);
+        Admin::RconSetPlayerIsAdmin(PlayerNumber(), true);
     }
 
     script "zh2_action_disableadmin" net
     {
-        Admin::RconSetPlayerAdmin(PlayerNumber(), false);
+        Admin::RconSetPlayerIsAdmin(PlayerNumber(), false);
     }
 
     /* DEBUG - GENERAL */
@@ -160,7 +160,7 @@ strict namespace ZH2Game
     script "zh2_action_debuggivestartweapons" net
     {
         // Can't be called when not offline, not in development and we are not admin.
-        if (!IsNetworkGame() && !IsDevelopment() && !Admin::GetAdmin())
+        if (!IsNetworkGame() && !IsDevelopment() && !Admin::GetIsAdmin())
         {
             Logger::LogActivator("You're not allowed to give yourself start weapons.");
             terminate;
@@ -487,7 +487,7 @@ strict namespace ZH2Game
     script "zh2_action_syncall" net
     {
         // Can't be called when not offline, not in development and we are not admin.
-        if (!IsNetworkGame() && !IsDevelopment() && !Admin::GetAdmin())
+        if (!IsNetworkGame() && !IsDevelopment() && !Admin::GetIsAdmin())
         {
             Logger::LogActivator("You're not allowed to call sync scripts.");
             terminate;
@@ -500,7 +500,7 @@ strict namespace ZH2Game
     script "zh2_action_callclientsyncall" net
     {
         // Can't be called when not offline, not in development and we are not admin.
-        if (!IsNetworkGame() && !IsDevelopment() && !Admin::GetAdmin())
+        if (!IsNetworkGame() && !IsDevelopment() && !Admin::GetIsAdmin())
         {
             Logger::LogActivator("You're not allowed to call sync scripts.");
             terminate;
@@ -513,7 +513,7 @@ strict namespace ZH2Game
     script "zh2_action_clientsyncall" net clientside
     {
         // Can't be called when not offline, not in development and we are not admin.
-        if (!IsNetworkGame() && !IsDevelopment() && !Admin::GetAdmin())
+        if (!IsNetworkGame() && !IsDevelopment() && !Admin::GetIsAdmin())
         {
             Logger::LogActivator("You're not allowed to call sync scripts.");
             terminate;

--- a/src/ZombieHorde2/acs_source/zh2game/binds.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/binds.acs
@@ -166,7 +166,7 @@ strict namespace ZH2Game
             terminate;
         }
 
-        Player::SpecieTypeT specie = Player::GetSpecie();
+        Player::PlayerSpecieT specie = Player::GetSpecie();
         ClearInventory();
 
         if (specie == Player::SPECIEHUMAN) Player::GiveHumanInventory(true);
@@ -455,7 +455,7 @@ strict namespace ZH2Game
                 str name = Reward::GetRewardName(i);
                 int weight = Reward::GetRewardWeight(i);
 
-                Player::SpecieTypeT specie = Reward::GetRewardSpecieSpecific(i);
+                Player::PlayerSpecieT specie = Reward::GetRewardSpecieSpecific(i);
 
                 str give = Reward::GetRewardGive(i);
                 str sound = Reward::GetRewardSound(i);

--- a/src/ZombieHorde2/acs_source/zh2game/decorate/blood.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/decorate/blood.acs
@@ -106,7 +106,7 @@ strict namespace Decorate
             terminate;
         SetActivator(-1);
 
-        Player::SpecieTypeT specie = Player::GetPlayerSpecie(targetId);
+        Player::PlayerSpecieT specie = Player::GetPlayerSpecie(targetId);
 
         // This is determined when we spawn blood.
         // If the specie changed we want to adjust to the correct blood type.

--- a/src/ZombieHorde2/acs_source/zh2game/decorate/items.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/decorate/items.acs
@@ -41,7 +41,7 @@ strict namespace Decorate
         if (!Player::GetPlayerIsHuman(PlayerNumber())) terminate;
         if (CheckInventory(ENERGY_ITEM) == 0) terminate;
 
-        Player::PanicStateT state = Player::GetPanicState();
+        Player::PlayerPanicStateT state = Player::GetPanicState();
         if (state == Player::PANICSTATEPANICKING)
         {
             Logger::LogActivator("You can't use this whilst panicking!");
@@ -77,7 +77,7 @@ strict namespace Decorate
         if (!Player::GetPlayerIsHuman(PlayerNumber())) terminate;
         if (CheckInventory(MEDIKIT_ITEM) == 0) terminate;
 
-        Player::PanicStateT state = Player::GetPanicState();
+        Player::PlayerPanicStateT state = Player::GetPanicState();
         if (state == Player::PANICSTATEPANICKING)
         {
             Logger::LogActivator("You can't use this whilst panicking!");

--- a/src/ZombieHorde2/acs_source/zh2game/events.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/events.acs
@@ -478,8 +478,8 @@ strict namespace ZH2Game
             + Player::GetSpecieIndexAsString(Player::GetPlayerSpecie(killedId)) + "\cj " + Player::GetPlayerName(killedId) + ".");
 
         // Determine kill type. Makes the stuff below simpler.
-        Player::SpecieTypeT killerSpecie = Player::GetPlayerSpecie(killerId);
-        Player::SpecieTypeT killedSpecie = Player::GetPlayerSpecie(killedId);
+        Player::PlayerSpecieT killerSpecie = Player::GetPlayerSpecie(killerId);
+        Player::PlayerSpecieT killedSpecie = Player::GetPlayerSpecie(killedId);
         KillTypeT killType =
             killerSpecie == Player::SPECIEHUMAN && killedSpecie == Player::SPECIEHUMAN ? KILL_TYPE_HUMAN_TO_HUMAN :
             killerSpecie == Player::SPECIEHUMAN && killedSpecie == Player::SPECIEZOMBIE ? KILL_TYPE_HUMAN_TO_ZOMBIE :
@@ -531,7 +531,7 @@ strict namespace ZH2Game
     {
         int id = (int)idRaw;
         int specieIndex = (int)specieIndexRaw;
-        Player::SpecieTypeT specie = Player::GetSpecieTypeByIndex(specieIndex);
+        Player::PlayerSpecieT specie = Player::GetSpecieTypeByIndex(specieIndex);
 
         // Full reset of powers on specie change.
         Power::ResetPlayerPowers(id);

--- a/src/ZombieHorde2/acs_source/zh2game/game/endgame.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/game/endgame.acs
@@ -46,7 +46,7 @@ strict namespace Game
         KillUnsafeZombies();
     }
 
-    internal void KillSpecies(Player::SpecieTypeT specie, bool checkIsSafe = true)
+    internal void KillSpecies(Player::PlayerSpecieT specie, bool checkIsSafe = true)
     {
         for (int i = 0; i < BCSUTILS::MAX_PLAYERS; i++)
         {

--- a/src/ZombieHorde2/acs_source/zh2game/game/specie.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/game/specie.acs
@@ -4,7 +4,7 @@
 
 strict namespace Game
 {
-    internal void ChangeSpecieInventory(Player::SpecieTypeT type, str item, int amount)
+    internal void ChangeSpecieInventory(Player::PlayerSpecieT type, str item, int amount)
     {
         ITERATESPECIES(type, {
             if (amount > 0) GiveActorInventory(tid, item, amount);
@@ -12,11 +12,11 @@ strict namespace Game
         });
     }
 
-    internal void GiveSpecieInventory(Player::SpecieTypeT type, str item, int amount) { ChangeSpecieInventory(type, item, amount); }
+    internal void GiveSpecieInventory(Player::PlayerSpecieT type, str item, int amount) { ChangeSpecieInventory(type, item, amount); }
     internal void GiveHumanInventory(str item, int amount)  { ChangeSpecieInventory(Player::SPECIEHUMAN, item, amount); }
     internal void GiveZombieInventory(str item, int amount) { ChangeSpecieInventory(Player::SPECIEZOMBIE, item, amount); }
 
-    internal void TakeSpecieInventory(Player::SpecieTypeT type, str item, int amount) { ChangeSpecieInventory(type, item, -amount); }
+    internal void TakeSpecieInventory(Player::PlayerSpecieT type, str item, int amount) { ChangeSpecieInventory(type, item, -amount); }
     internal void TakeHumanInventory(str item, int amount)  { ChangeSpecieInventory(Player::SPECIEHUMAN, item, -amount); }
     internal void TakeZombieInventory(str item, int amount) { ChangeSpecieInventory(Player::SPECIEZOMBIE, item, -amount); }
 }

--- a/src/ZombieHorde2/acs_source/zh2game/game/team.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/game/team.acs
@@ -59,7 +59,7 @@ strict namespace Game
     // Handles actually setting the alpha values on all team indicators and warping them.
     internal void UpdateTeamIndicators()
     {
-        Player::SpecieTypeT specie = Player::GetSpecie();
+        Player::PlayerSpecieT specie = Player::GetSpecie();
         int consolePlayerTid = Identity::GetTid(ConsolePlayerNumber());
         fixed translucentTeamIndicatorsDistance = fixed(ZH2Game::GetTeamIndicatorDistance());
 
@@ -95,7 +95,7 @@ strict namespace Game
                 continue;
 
             fixed zOffset = GetActorProperty(tid, APROP_VIEWHEIGHT) + 16.0;
-            Player::SpecieTypeT playerSpecie = Player::GetPlayerSpecie(i);
+            Player::PlayerSpecieT playerSpecie = Player::GetPlayerSpecie(i);
 
             // Zombies are taller than their view height.
             if (playerSpecie == Player::SPECIEZOMBIE)

--- a/src/ZombieHorde2/acs_source/zh2game/hud/drawhud/admin/player.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/hud/drawhud/admin/player.acs
@@ -13,7 +13,7 @@ strict namespace Hud
 
     // Used to pass along species when pressing buttons for specie specific players.
     // Can be set using the buttons.
-    internal Player::SpecieTypeT _filteredSpecie;
+    internal Player::PlayerSpecieT _filteredSpecie;
 
     internal void DrawPlayerMenuHud()
     {
@@ -129,7 +129,7 @@ strict namespace Hud
 
         for (int i = Player::SPECIENONE; i <= Player::SPECIEZOMBIE; ++i)
         {
-            Player::SpecieTypeT specie = Player::GetSpecieTypeByIndex(i);
+            Player::PlayerSpecieT specie = Player::GetSpecieTypeByIndex(i);
             str label = specie == Player::SPECIENONE
                 ? "all"
                 : Player::GetSpecieIndexAsString(specie);

--- a/src/ZombieHorde2/acs_source/zh2game/hud/drawhud/player/identity.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/hud/drawhud/player/identity.acs
@@ -39,7 +39,7 @@ strict namespace Hud
         int playerId = Identity::GetId(targetTid);
         int id = HUDID_IDENTITY;
 
-        Player::SpecieTypeT specieSelf = Player::GetSpecie();
+        Player::PlayerSpecieT specieSelf = Player::GetSpecie();
 
         BCSUtils::HudSetCenterText(true);
         BCSUtils::HudSetDisappearTime(0.5);
@@ -53,7 +53,7 @@ strict namespace Hud
         if (!Round::GetGameIsPlaying())
             return;
 
-        Player::SpecieTypeT specie = Player::GetPlayerSpecie(playerId);
+        Player::PlayerSpecieT specie = Player::GetPlayerSpecie(playerId);
         str specieLabel = Player::GetSpecieIndexAsString(specie);
 
         BCSUtils::HudSetFont("SmallFont");

--- a/src/ZombieHorde2/acs_source/zh2game/hud/drawhud/player/inventory.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/hud/drawhud/player/inventory.acs
@@ -56,7 +56,7 @@ strict namespace Hud
             return;
 
         // We use the specie of the player to determine if the item can be used.
-        Player::SpecieTypeT specie = Player::GetSpecie();
+        Player::PlayerSpecieT specie = Player::GetSpecie();
 
         int drawnCount = ZH2Game::GetShownInventoryItems();
         int drawnSideCount = int(BCSUtils::Floor(fixed(drawnCount) / 2.0));
@@ -126,7 +126,7 @@ strict namespace Hud
         }
     }
 
-    internal void DrawInventoryItem(Player::SpecieTypeT ownerSpecie, int index, fixed addX, fixed alpha, bool current)
+    internal void DrawInventoryItem(Player::PlayerSpecieT ownerSpecie, int index, fixed addX, fixed alpha, bool current)
     {
         // Note if we didn't set this data then just assume it can be used.
         bool humanOwned = Item::GetItemHumanOwned(index);

--- a/src/ZombieHorde2/acs_source/zh2game/main.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/main.acs
@@ -666,9 +666,9 @@ strict namespace ZH2Game
 
         // Set the player as an admin.
         // This is now removed and you can turn it on through the menu/rcon. Always works offline.
-        // if (!Admin::GetAdmin())
+        // if (!Admin::GetIsAdmin())
         // {
-        //     Admin::SetAdmin(true);
+        //     Admin::SetIsAdmin(true);
         //     Sync::SyncAdmins();
         // }
     }

--- a/src/ZombieHorde2/acs_source/zh2game/main.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/main.acs
@@ -40,7 +40,7 @@ strict namespace ZH2Game
     // This is used for joining players/bots to force them to a specific specie.
     // This is specifically used for the admin to add bots of specific species.
     // If not set, we default to humans.
-    internal Player::SpecieTypeT _forceSpecie;
+    internal Player::PlayerSpecieT _forceSpecie;
 
     script "zh2_internal_open" open
     {

--- a/src/ZombieHorde2/acs_source/zh2game/main.h.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/main.h.acs
@@ -238,7 +238,7 @@ strict namespace ZH2Game
         str StrippedName;
 
         Player::PlayerStateT State;
-        Player::SpecieTypeT SpecieType;
+        Player::PlayerSpecieT SpecieType;
         bool IsInitialZombie;
         bool Safe;
 
@@ -246,7 +246,7 @@ strict namespace ZH2Game
         bool AlwaysAllowJoin;
 
         // TODO: Sync this state, maybe make use of it.
-        Player::PanicStateT PanicState;
+        Player::PlayerPanicStateT PanicState;
         int PanicCount;
 
         // Not synched.

--- a/src/ZombieHorde2/acs_source/zh2game/player/log.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/log.acs
@@ -7,7 +7,7 @@ strict namespace Player
     internal void LogBoldToHumans(str message) { LogBoldToSpecies(SPECIEHUMAN, message); }
     internal void LogBoldToZombies(str message) { LogBoldToSpecies(SPECIEZOMBIE, message); }
 
-    internal void LogBoldToSpecies(SpecieTypeT specie, str message)
+    internal void LogBoldToSpecies(PlayerSpecieT specie, str message)
     {
         for (int i = 0; i < BCSUTILS::MAX_PLAYERS; ++i)
         {

--- a/src/ZombieHorde2/acs_source/zh2game/player/panic.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/panic.acs
@@ -6,7 +6,7 @@ strict namespace Player
 {
     internal void PanicTic()
     {
-        PanicStateT state = GetPanicState();
+        PlayerPanicStateT state = GetPanicState();
 
         // Player did not panic or already finished panicking.
         if (state == PANICSTATENONE)
@@ -46,7 +46,7 @@ strict namespace Player
     {
         if (!BCSUtils::IsAlive()) return;
 
-        PanicStateT state = GetPanicState();
+        PlayerPanicStateT state = GetPanicState();
         if (state == PANICSTATEPANICKING)
         {
             Logger::LogActivator("You are already panicking!");
@@ -115,22 +115,22 @@ strict namespace Player
         ThingSound(ActivatorTID(), "*death", 127);
     }
 
-    internal PanicStateT GetPanicState()
+    internal PlayerPanicStateT GetPanicState()
     {
         return GetPlayerPanicState(PlayerNumber());
     }
 
-    internal PanicStateT GetPlayerPanicState(int id)
+    internal PlayerPanicStateT GetPlayerPanicState(int id)
     {
         return ZH2Game::GameContext.Players[id].PanicState;
     }
 
-    internal void SetPanicState(PanicStateT state)
+    internal void SetPanicState(PlayerPanicStateT state)
     {
         SetPlayerPanicState(PlayerNumber(), state);
     }
 
-    internal void SetPlayerPanicState(int id, PanicStateT state)
+    internal void SetPlayerPanicState(int id, PlayerPanicStateT state)
     {
         ZH2Game::GameContext.Players[id].PanicState = state;
     }

--- a/src/ZombieHorde2/acs_source/zh2game/player/player.h.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/player.h.acs
@@ -4,7 +4,7 @@
 
 strict namespace Player
 {
-    enum SpecieTypeT : int
+    enum PlayerSpecieT : int
     {
         SPECIENONE,
         SPECIEHUMAN,
@@ -25,7 +25,7 @@ strict namespace Player
         STATEDEAD,
     };
 
-    internal enum PanicStateT : int
+    internal enum PlayerPanicStateT : int
     {
         PANICSTATENONE,
         PANICSTATEPANICKING,

--- a/src/ZombieHorde2/acs_source/zh2game/player/specie.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/specie.acs
@@ -4,21 +4,21 @@
 
 strict namespace Player
 {
-    internal SpecieTypeT GetSpecie()
+    internal PlayerSpecieT GetSpecie()
     {
         return GetPlayerSpecie(PlayerNumber());
     }
-    internal SpecieTypeT GetPlayerSpecie(int id)
+    internal PlayerSpecieT GetPlayerSpecie(int id)
     {
         if (!Identity::IsValidID(id)) return SPECIENONE;
         return ZH2Game::GameContext.Players[id].SpecieType;
     }
 
-    internal bool SetSpecie(SpecieTypeT specie)
+    internal bool SetSpecie(PlayerSpecieT specie)
     {
         return SetPlayerSpecie(PlayerNumber(), specie);
     }
-    internal bool SetPlayerSpecie(int id, SpecieTypeT specie)
+    internal bool SetPlayerSpecie(int id, PlayerSpecieT specie)
     {
         if (!Identity::IsValidID(id)) return false;
         ZH2Game::GameContext.Players[id].SpecieType = specie;
@@ -56,7 +56,7 @@ strict namespace Player
         SetResultValue(int(GetIsHuman()));
     }
 
-    internal int SpecieCount(SpecieTypeT type, bool includeDead = false)
+    internal int SpecieCount(PlayerSpecieT type, bool includeDead = false)
     {
         int count;
         for (int i = 0; i < BCSUtils::MAX_PLAYERS; ++i)
@@ -85,12 +85,12 @@ strict namespace Player
         return SpecieCount(SPECIEZOMBIE, includeDead);
     }
 
-    internal SpecieTypeT GetSpecieTypeByIndex(int index)
+    internal PlayerSpecieT GetSpecieTypeByIndex(int index)
     {
         if (index <= SPECIENONE || index > SPECIEZOMBIE)
             return SPECIENONE;
 
-        static SpecieTypeT collection[] = { SPECIEHUMAN, SPECIEZOMBIE };
+        static PlayerSpecieT collection[] = { SPECIEHUMAN, SPECIEZOMBIE };
         return collection[index - 1];
     }
 

--- a/src/ZombieHorde2/acs_source/zh2game/player/sprint.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/sprint.acs
@@ -62,7 +62,7 @@ strict namespace Player
             return;
         }
 
-        PanicStateT state = GetPlayerPanicState(id);
+        PlayerPanicStateT state = GetPlayerPanicState(id);
         if (state == PANICSTATEPANICKING)
         {
             Logger::LogTo(id, "You are panicking!");

--- a/src/ZombieHorde2/acs_source/zh2game/player/translucentallies.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/player/translucentallies.acs
@@ -59,7 +59,7 @@ strict namespace Player
     // Handles actually setting the alpha values on all actors.
     internal void UpdateTranslucentAlliesAlpha()
     {
-        Player::SpecieTypeT specie = Player::GetSpecie();
+        Player::PlayerSpecieT specie = Player::GetSpecie();
         fixed translucentAlliesDistance = fixed(ZH2Game::GetTranslucentAlliesDistance());
 
         // Base configured translucency value on players.

--- a/src/ZombieHorde2/acs_source/zh2game/reward/givereward.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/reward/givereward.acs
@@ -64,14 +64,14 @@ strict namespace Reward
 
     internal bool GetCanGivePlayerReward(int id, int index)
     {
-        Player::SpecieTypeT specie = Player::GetPlayerSpecie(id);
+        Player::PlayerSpecieT specie = Player::GetPlayerSpecie(id);
 
         // Conditionally check for specie.
         // Both instances must be specie specific.
         // If one doesn't provide it we assume the reward can be for any specie.
         if (specie != Player::SPECIENONE)
         {
-            Player::SpecieTypeT rewardSpecie = Reward::GetRewardSpecieSpecific(index);
+            Player::PlayerSpecieT rewardSpecie = Reward::GetRewardSpecieSpecific(index);
             if (rewardSpecie != Player::SPECIENONE && specie != rewardSpecie)
                 return false;
         }

--- a/src/ZombieHorde2/acs_source/zh2game/reward/reward.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/reward/reward.acs
@@ -17,7 +17,7 @@ strict namespace Reward
     internal int GetRewardFlags(int index) { return ZH2Game::PersistingGameContext.RewardCollection.Collection[index].ContainerFlags; }
     internal str GetRewardName(int index) { return ZH2Game::PersistingGameContext.RewardCollection.Collection[index].Name; }
     internal int GetRewardWeight(int index) { return ZH2Game::PersistingGameContext.RewardCollection.Collection[index].Weight; }
-    internal Player::SpecieTypeT GetRewardSpecieSpecific(int index) { return ZH2Game::PersistingGameContext.RewardCollection.Collection[index].SpecieSpecific; }
+    internal Player::PlayerSpecieT GetRewardSpecieSpecific(int index) { return ZH2Game::PersistingGameContext.RewardCollection.Collection[index].SpecieSpecific; }
     internal str GetRewardCallRestrict(int index) { return ZH2Game::PersistingGameContext.RewardCollection.Collection[index].CallRestrict; }
     internal str GetRewardCallGive(int index) { return ZH2Game::PersistingGameContext.RewardCollection.Collection[index].CallGive; }
     internal str GetRewardGive(int index) { return ZH2Game::PersistingGameContext.RewardCollection.Collection[index].Give; }

--- a/src/ZombieHorde2/acs_source/zh2game/reward/reward.h.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/reward/reward.h.acs
@@ -20,7 +20,7 @@ strict namespace Reward
         int ContainerFlags;
         str Name;
         int Weight;
-        Player::SpecieTypeT SpecieSpecific;
+        Player::PlayerSpecieT SpecieSpecific;
         str CallRestrict;
         str CallGive;
         str Give;

--- a/src/ZombieHorde2/acs_source/zh2game/sync/actor/admin.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/sync/actor/admin.acs
@@ -43,7 +43,7 @@ strict namespace Sync
                 return syncId;
             }
 
-            bool isAdmin = Admin::GetPlayerAdmin(i);
+            bool isAdmin = Admin::GetPlayerIsAdmin(i);
             BitMath::SetBit64(BitMath::GetBitPack1(), BitMath::GetBitPack2(), i, isAdmin);
 
             if (PlayerInGame(i))


### PR DESCRIPTION
Rename `GetAdmin` to `GetIsAdmin`
Rename `GetPlayerAdmin` to `GetPlayerIsAdmin`
Rename `SetAdmin` to `SetIsAdmin`
Rename `SetPlayerAdmin` to `SetPlayerIsAdmin`
Rename `BroadcastAdmin` to `BroadcastPlayerAdmin`
New function `BroadcastAdmin` for broadcasting the activator as an admin.

Rename `SpecieTypeT` to `PlayerSpecieT`
Rename `PanicStateT` to `PlayerPanicStateT`

Rename `zh2_enableadminplayer` to `zh2_admin_playerenable`
Rename `zh2_disableadminplayer` to `zh2_admin_playerdisable`
New function `RconSetIsAdmin` for setting/unsetting the activator as an admin.