### PR TITLE
Add support for new Zandronum 3.3 feature `CheckScript`

### DIFF
--- a/libsrc/acs_source/eventbus/eventbus.acs
+++ b/libsrc/acs_source/eventbus/eventbus.acs
@@ -10,6 +10,13 @@ strict namespace EventBus
 {
     void AddCallbackByScriptName(str eventKey, str scriptName)
     {
+        // Ensure this script exists.
+        if (!CheckScript(scriptName, true))
+        {
+            Logger::LogError(LOGSOURCE , "Failed to add event " + eventKey + " with script name callback " + scriptName +". Script not found.");
+            return;
+        }
+
         int index = EnsureEventExists(eventKey);
         if (index == -1)
         {
@@ -30,6 +37,13 @@ strict namespace EventBus
 
     void AddCallbackByScriptNumber(str eventKey, int scriptNumber)
     {
+        // Ensure this script exists.
+        if (!CheckScript(scriptNumber, false))
+        {
+            Logger::LogError(LOGSOURCE , "Failed to add event " + eventKey + " with script number callback " + str(scriptNumber) +". Script not found.");
+            return;
+        }
+
         int index = EnsureEventExists(eventKey);
         if (index == -1)
         {
@@ -125,4 +139,4 @@ strict namespace EventBus
     }
 }
 
-#undef LOGSOURCE 
+#undef LOGSOURCE

--- a/tools/Zt-bcc_x86/lib/zcommon.bcs
+++ b/tools/Zt-bcc_x86/lib/zcommon.bcs
@@ -1809,6 +1809,7 @@ special
 -183:SetControlPointInfo(raw, raw, raw):raw,
 -184:GetSkinProperty(raw, raw; raw, raw):raw,
 -185:IsPlayerContestingControlPoint(raw, raw):raw,
+-188:CheckScript(raw, bool):bool,
 
 
 // ZDoom/GZDoom.


### PR DESCRIPTION
Adds support for the new function added in Zandronum 3.3, `CheckScript`.
ACC: `-188: CheckScript( mixed script, bool named )`
BCC: `-188:CheckScript(raw, bool):bool,`

Added to the eventbus as it allows mappers to define callbacks. These should be verified beforehand to exist.