### PR TITLE
Fix texture duplicates in textures.drressources & textures.zm17.

### DIFF
--- a/src/ZombieHorde2Legacy/textures.drresources
+++ b/src/ZombieHorde2Legacy/textures.drresources
@@ -382,7 +382,7 @@ WallTexture "F0023", 64, 64
     Patch "F0023", 0, 0
 }
 
-WallTexture "F0025 ", 64, 64
+WallTexture "F0025", 64, 64
 {
     Patch "F0025", 0, 0
 }

--- a/src/ZombieHorde2Legacy/textures.zm17
+++ b/src/ZombieHorde2Legacy/textures.zm17
@@ -106,56 +106,6 @@ WallTexture "N_GRT02A", 112, 88
     Patch "N_GRT02A", 0, 0
 }
 
-WallTexture "N_GRAYX1", 64, 64
-{
-    Patch "N_GRAYX1", 0, 0
-}
-
-WallTexture "N_GRAY71", 128, 64
-{
-    Patch "N_GRAY71", 0, 0
-}
-
-WallTexture "N_GRAY74", 128, 64
-{
-    Patch "N_GRAY74", 0, 0
-}
-
-WallTexture "N_GRAY64", 128, 128
-{
-    Patch "N_GRAY64", 0, 0
-}
-
-WallTexture "N_GRAY65", 128, 128
-{
-    Patch "N_GRAY65", 0, 0
-}
-
-WallTexture "N_GRAY66", 128, 128
-{
-    Patch "N_GRAY66", 0, 0
-}
-
-WallTexture "N_GRAY67", 128, 128
-{
-    Patch "N_GRAY67", 0, 0
-}
-
-WallTexture "N_GRAY39", 128, 128
-{
-    Patch "N_GRAY39", 0, 0
-}
-
-WallTexture "N_GRAY40", 128, 128
-{
-    Patch "N_GRAY40", 0, 0
-}
-
-WallTexture "N_GRAY27", 64, 128
-{
-    Patch "N_GRAY27", 0, 0
-}
-
 WallTexture "GRAY16", 128, 128
 {
     Patch "GRAY16", 0, 0
@@ -229,11 +179,6 @@ WallTexture "N_MT5E06", 64, 64
 WallTexture "N_LTBL06", 8, 128
 {
     Patch "N_LTBL06", 0, 0
-}
-
-WallTexture "N_GRAY56", 64, 64
-{
-    Patch "N_GRAY56", 0, 0
 }
 
 WallTexture "CGCRTE00", 128, 128
@@ -566,11 +511,6 @@ WallTexture "0_LITEWG", 64, 64
     Patch "0_LITEWG", 0, 0
 }
 
-WallTexture "N_GRAY63", 128, 128
-{
-    Patch "N_GRAY63", 0, 0
-}
-
 WallTexture "COMPS1", 256, 128
 {
     Patch "COMPS1", 0, 0
@@ -579,26 +519,6 @@ WallTexture "COMPS1", 256, 128
 WallTexture "COMP93", 256, 64
 {
     Patch "COMP93", 0, 0
-}
-
-WallTexture "N_GRAY75", 128, 128
-{
-    Patch "N_GRAY75", 0, 0
-}
-
-WallTexture "N_GRAY76", 128, 128
-{
-    Patch "N_GRAY76", 0, 0
-}
-
-WallTexture "N_GRAY77", 128, 128
-{
-    Patch "N_GRAY77", 0, 0
-}
-
-WallTexture "N_GRAY73", 128, 128
-{
-    Patch "N_GRAY73", 0, 0
 }
 
 WallTexture "GSGRAY01", 64, 64


### PR DESCRIPTION
textures.zm17 lump contains a duplicate redefinition of N_GRAY.

In textures.drressources lump, F0025 texture was redefined with a weird char added to it.