### PR TITLE
Ensure reward restrict/give scripts exist when parsed

### DIFF
--- a/src/ZombieHorde2/acs_source/zh2game/io/mod/shared/reward.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/io/mod/shared/reward.acs
@@ -227,8 +227,17 @@ strict namespace IO
             return false;
         }
 
+        str scriptName = Tokenizer::GetSymbol(handle);
+
+        // Ensure this script exists.
+        if (!CheckScript(scriptName, true))
+        {
+            Tokenizer::SetErrored(handle, "Unknown script name when parsing reward restrict script: \"" + scriptName + "\".");
+            return false;
+        }
+
         Reward::RewardContextT global:PERSISTINGGAMECONTEXTINDEX& context = ZH2Game::PersistingGameContext.RewardCollection.Collection[ZH2Game::PersistingGameContext.RewardCollection.Count];
-        context.CallRestrict = Tokenizer::GetSymbol(handle);
+        context.CallRestrict = scriptName;
 
         Logger::LogDebug(LOGSOURCE , "Parsed reward call restrict: \cd" + context.CallRestrict + "\cj.");
         return true;
@@ -247,8 +256,17 @@ strict namespace IO
             return false;
         }
 
+        str scriptName = Tokenizer::GetSymbol(handle);
+
+        // Ensure this script exists.
+        if (!CheckScript(scriptName, true))
+        {
+            Tokenizer::SetErrored(handle, "Unknown script name when parsing reward give script: \"" + scriptName + "\".");
+            return false;
+        }
+
         Reward::RewardContextT global:PERSISTINGGAMECONTEXTINDEX& context = ZH2Game::PersistingGameContext.RewardCollection.Collection[ZH2Game::PersistingGameContext.RewardCollection.Count];
-        context.CallGive = Tokenizer::GetSymbol(handle);
+        context.CallGive = scriptName;
 
         Logger::LogDebug(LOGSOURCE , "Parsed reward call give: \cd" + context.CallGive + "\cj.");
         return true;

--- a/src/ZombieHorde2/acs_source/zh2game/reward/givereward.acs
+++ b/src/ZombieHorde2/acs_source/zh2game/reward/givereward.acs
@@ -80,7 +80,6 @@ strict namespace Reward
 
         // Check for restriction.
         // Restriction means there's some reason the item can't be given (restricted/duplicate/disabled/etc).
-        // TODO: We should error if the script does not exist.
         str callRestrict = GetRewardCallRestrict(index);
         if (callRestrict != (raw)0 && callRestrict != ""
             && ACS_NamedExecuteWithResult(callRestrict, id))
@@ -118,8 +117,6 @@ strict namespace Reward
 
         if ((raw)callGive != 0 && callGive != "")
         {
-            // TODO: We should error if the script does not exist.
-            // Logger::logError(LOGSOURCE , "Failed to call script \"" + callGive + "\" for reward index " + str(index) + ".");
             ACS_NamedExecuteWithResult(callGive, id);
         }
 


### PR DESCRIPTION
Uses a new Zandronum 3.3 feature to check if a script exists. Used when parsing rewards to ensure the restrict/give scripts exist.