### PR TITLE
Fix support2 4 texture transfert

### DIFF
--- a/mapsrc/ZombieHorde2Legacy/ZE32/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZE32/TEXTMAP
@@ -243392,53 +243392,53 @@ texturebottom = "CRATWIDE";
 sidedef // 7575
 {
 sector = 558;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7576
 {
 sector = 562;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7577
 {
 sector = 964;
 offsetx = 160;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7578
 {
 sector = 562;
 offsetx = 80;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7579
 {
 sector = 558;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7580
 {
 sector = 562;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7581
 {
 sector = 569;
 offsetx = 80;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7582
 {
 sector = 562;
 offsetx = 176;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7583
@@ -243467,39 +243467,39 @@ offsetx = 16;
 sidedef // 7587
 {
 sector = 559;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7588
 {
 sector = 564;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7589
 {
 sector = 559;
 offsetx = 192;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7590
 {
 sector = 565;
 offsetx = 192;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7591
 {
 sector = 559;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7592
 {
 sector = 564;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7593
@@ -243524,7 +243524,7 @@ offsetx = 320;
 sidedef // 7596
 {
 sector = 563;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7597
@@ -243589,21 +243589,21 @@ sector = 560;
 sidedef // 7608
 {
 sector = 569;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7609
 {
 sector = 559;
 offsetx = 192;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7610
 {
 sector = 964;
 offsetx = 192;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7611
@@ -243657,53 +243657,53 @@ sector = 565;
 sidedef // 7619
 {
 sector = 567;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7620
 {
 sector = 561;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7621
 {
 sector = 561;
 offsetx = 192;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7622
 {
 sector = 565;
 offsetx = 192;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7623
 {
 sector = 567;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7624
 {
 sector = 561;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7625
 {
 sector = 561;
 offsetx = 192;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7626
 {
 sector = 964;
 offsetx = 192;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7627
@@ -243743,13 +243743,13 @@ sector = 565;
 sidedef // 7633
 {
 sector = 563;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7634
 {
 sector = 557;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7635
@@ -243762,14 +243762,14 @@ sidedef // 7636
 {
 sector = 569;
 offsetx = 176;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7637
 {
 sector = 557;
 offsetx = 112;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7638
@@ -243781,13 +243781,13 @@ texturemiddle = "SHAWN2";
 sidedef // 7639
 {
 sector = 563;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7640
 {
 sector = 557;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7641
@@ -243800,14 +243800,14 @@ sidedef // 7642
 {
 sector = 964;
 offsetx = 112;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7643
 {
 sector = 557;
 offsetx = 160;
-texturetop = "SUPPORT2";
+texturetop = "SUPPORT4";
 }
 
 sidedef // 7644
@@ -243879,13 +243879,13 @@ offsetx = 176;
 sidedef // 7655
 {
 sector = 571;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7656
 {
 sector = 573;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7657
@@ -243896,7 +243896,7 @@ sector = 568;
 sidedef // 7658
 {
 sector = 964;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7659
@@ -244005,7 +244005,7 @@ sidedef // 7675
 sector = 565;
 offsetx = 240;
 offsety = 24;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7676
@@ -244016,14 +244016,14 @@ sector = 571;
 sidedef // 7677
 {
 sector = 570;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7678
 {
 sector = 574;
 offsetx = 608;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7679
@@ -244040,44 +244040,44 @@ sector = 571;
 sidedef // 7681
 {
 sector = 570;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7682
 {
 sector = 571;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7683
 {
 sector = 964;
 offsetx = 736;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7684
 {
 sector = 571;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7685
 {
 sector = 964;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7686
 {
 sector = 574;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7687
 {
 sector = 571;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7688
@@ -244097,14 +244097,14 @@ sidedef // 7690
 {
 sector = 571;
 offsetx = 368;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7691
 {
 sector = 964;
 offsetx = 384;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7692
@@ -244116,7 +244116,7 @@ texturebottom = "PLAT1";
 sidedef // 7693
 {
 sector = 576;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7694
@@ -244134,33 +244134,33 @@ texturebottom = "PLAT1";
 sidedef // 7696
 {
 sector = 576;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7697
 {
 sector = 571;
 offsetx = 752;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7698
 {
 sector = 964;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7699
 {
 sector = 574;
 offsetx = 736;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7700
 {
 sector = 571;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7701
@@ -244172,7 +244172,7 @@ sidedef // 7702
 {
 sector = 964;
 offsetx = 16;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7703
@@ -244184,7 +244184,7 @@ sidedef // 7704
 {
 sector = 558;
 offsetx = 592;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7705
@@ -244218,7 +244218,7 @@ sidedef // 7710
 {
 sector = 564;
 offsetx = 368;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7711
@@ -244231,7 +244231,7 @@ sidedef // 7712
 {
 sector = 567;
 offsetx = 224;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7713
@@ -244283,14 +244283,14 @@ sidedef // 7721
 {
 sector = 574;
 offsetx = 368;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7722
 {
 sector = 571;
 offsetx = 352;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7723
@@ -244330,13 +244330,13 @@ offsetx = 240;
 sidedef // 7729
 {
 sector = 571;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7730
 {
 sector = 573;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7731
@@ -244370,13 +244370,13 @@ offsetx = 16;
 sidedef // 7736
 {
 sector = 964;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7737
 {
 sector = 560;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7738
@@ -244387,7 +244387,7 @@ sector = 566;
 sidedef // 7739
 {
 sector = 560;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7740
@@ -244399,7 +244399,7 @@ offsetx = 288;
 sidedef // 7741
 {
 sector = 560;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7742
@@ -244410,7 +244410,7 @@ sector = 568;
 sidedef // 7743
 {
 sector = 560;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7744
@@ -244947,14 +244947,14 @@ texturebottom = "SHAWN2";
 sidedef // 7825
 {
 sector = 574;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7826
 {
 sector = 571;
 offsetx = 720;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 7827
@@ -275533,7 +275533,7 @@ sidedef // 12862
 {
 sector = 560;
 offsetx = 288;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 12863
@@ -302775,7 +302775,7 @@ texturemiddle = "VICT-022";
 sidedef // 17445
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17446
@@ -302786,7 +302786,7 @@ sector = 1508;
 sidedef // 17447
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17448
@@ -302797,7 +302797,7 @@ sector = 1508;
 sidedef // 17449
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17450
@@ -302808,7 +302808,7 @@ sector = 1508;
 sidedef // 17451
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17452
@@ -302819,7 +302819,7 @@ sector = 1508;
 sidedef // 17453
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17454
@@ -302830,7 +302830,7 @@ sector = 1508;
 sidedef // 17455
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17456
@@ -302841,7 +302841,7 @@ sector = 1508;
 sidedef // 17457
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17458
@@ -302852,7 +302852,7 @@ sector = 1508;
 sidedef // 17459
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17460
@@ -302863,7 +302863,7 @@ sector = 1508;
 sidedef // 17461
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17462
@@ -302874,7 +302874,7 @@ sector = 1508;
 sidedef // 17463
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17464
@@ -302885,7 +302885,7 @@ sector = 1508;
 sidedef // 17465
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17466
@@ -302896,7 +302896,7 @@ sector = 1508;
 sidedef // 17467
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17468
@@ -302907,151 +302907,151 @@ sector = 1508;
 sidedef // 17469
 {
 sector = 1508;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17470
 {
 sector = 1509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17471
 {
 sector = 1508;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17472
 {
 sector = 1509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17473
 {
 sector = 1508;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17474
 {
 sector = 1509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17475
 {
 sector = 1508;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17476
 {
 sector = 1509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17477
 {
 sector = 1508;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17478
 {
 sector = 1509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17479
 {
 sector = 1508;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17480
 {
 sector = 1509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17481
 {
 sector = 1508;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17482
 {
 sector = 1509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17483
 {
 sector = 1508;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17484
 {
 sector = 1509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17485
 {
 sector = 1508;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17486
 {
 sector = 1509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17487
 {
 sector = 1508;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17488
 {
 sector = 1509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17489
 {
 sector = 1508;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17490
 {
 sector = 1509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17491
 {
 sector = 1508;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17492
 {
 sector = 1509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17493
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17494
@@ -303062,7 +303062,7 @@ sector = 1510;
 sidedef // 17495
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17496
@@ -303073,7 +303073,7 @@ sector = 1510;
 sidedef // 17497
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17498
@@ -303084,7 +303084,7 @@ sector = 1510;
 sidedef // 17499
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17500
@@ -303095,7 +303095,7 @@ sector = 1510;
 sidedef // 17501
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17502
@@ -303106,7 +303106,7 @@ sector = 1510;
 sidedef // 17503
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17504
@@ -303117,7 +303117,7 @@ sector = 1510;
 sidedef // 17505
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17506
@@ -303128,7 +303128,7 @@ sector = 1510;
 sidedef // 17507
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17508
@@ -303139,7 +303139,7 @@ sector = 1510;
 sidedef // 17509
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17510
@@ -303150,7 +303150,7 @@ sector = 1510;
 sidedef // 17511
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17512
@@ -303161,7 +303161,7 @@ sector = 1510;
 sidedef // 17513
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17514
@@ -303172,7 +303172,7 @@ sector = 1510;
 sidedef // 17515
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17516
@@ -303183,151 +303183,151 @@ sector = 1510;
 sidedef // 17517
 {
 sector = 1510;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17518
 {
 sector = 1511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17519
 {
 sector = 1510;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17520
 {
 sector = 1511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17521
 {
 sector = 1510;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17522
 {
 sector = 1511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17523
 {
 sector = 1510;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17524
 {
 sector = 1511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17525
 {
 sector = 1510;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17526
 {
 sector = 1511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17527
 {
 sector = 1510;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17528
 {
 sector = 1511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17529
 {
 sector = 1510;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17530
 {
 sector = 1511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17531
 {
 sector = 1510;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17532
 {
 sector = 1511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17533
 {
 sector = 1510;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17534
 {
 sector = 1511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17535
 {
 sector = 1510;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17536
 {
 sector = 1511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17537
 {
 sector = 1510;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17538
 {
 sector = 1511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17539
 {
 sector = 1510;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17540
 {
 sector = 1511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17541
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17542
@@ -303338,7 +303338,7 @@ sector = 1512;
 sidedef // 17543
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17544
@@ -303349,7 +303349,7 @@ sector = 1512;
 sidedef // 17545
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17546
@@ -303360,7 +303360,7 @@ sector = 1512;
 sidedef // 17547
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17548
@@ -303371,7 +303371,7 @@ sector = 1512;
 sidedef // 17549
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17550
@@ -303382,7 +303382,7 @@ sector = 1512;
 sidedef // 17551
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17552
@@ -303393,7 +303393,7 @@ sector = 1512;
 sidedef // 17553
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17554
@@ -303404,7 +303404,7 @@ sector = 1512;
 sidedef // 17555
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17556
@@ -303415,7 +303415,7 @@ sector = 1512;
 sidedef // 17557
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17558
@@ -303426,7 +303426,7 @@ sector = 1512;
 sidedef // 17559
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17560
@@ -303437,7 +303437,7 @@ sector = 1512;
 sidedef // 17561
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17562
@@ -303448,7 +303448,7 @@ sector = 1512;
 sidedef // 17563
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17564
@@ -303459,145 +303459,145 @@ sector = 1512;
 sidedef // 17565
 {
 sector = 1512;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17566
 {
 sector = 1513;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17567
 {
 sector = 1512;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17568
 {
 sector = 1513;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17569
 {
 sector = 1512;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17570
 {
 sector = 1513;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17571
 {
 sector = 1512;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17572
 {
 sector = 1513;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17573
 {
 sector = 1512;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17574
 {
 sector = 1513;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17575
 {
 sector = 1512;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17576
 {
 sector = 1513;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17577
 {
 sector = 1512;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17578
 {
 sector = 1513;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17579
 {
 sector = 1512;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17580
 {
 sector = 1513;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17581
 {
 sector = 1512;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17582
 {
 sector = 1513;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17583
 {
 sector = 1512;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17584
 {
 sector = 1513;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17585
 {
 sector = 1512;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17586
 {
 sector = 1513;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17587
 {
 sector = 1512;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17588
 {
 sector = 1513;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17589
@@ -303640,7 +303640,7 @@ texturemiddle = "VICT-023";
 sidedef // 17595
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17596
@@ -303651,7 +303651,7 @@ sector = 1515;
 sidedef // 17597
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17598
@@ -303662,7 +303662,7 @@ sector = 1515;
 sidedef // 17599
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17600
@@ -303673,7 +303673,7 @@ sector = 1515;
 sidedef // 17601
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17602
@@ -303684,7 +303684,7 @@ sector = 1515;
 sidedef // 17603
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17604
@@ -303695,7 +303695,7 @@ sector = 1515;
 sidedef // 17605
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17606
@@ -303706,7 +303706,7 @@ sector = 1515;
 sidedef // 17607
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17608
@@ -303717,7 +303717,7 @@ sector = 1515;
 sidedef // 17609
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17610
@@ -303728,7 +303728,7 @@ sector = 1515;
 sidedef // 17611
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17612
@@ -303739,7 +303739,7 @@ sector = 1515;
 sidedef // 17613
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17614
@@ -303750,7 +303750,7 @@ sector = 1515;
 sidedef // 17615
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17616
@@ -303761,7 +303761,7 @@ sector = 1515;
 sidedef // 17617
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17618
@@ -303772,151 +303772,151 @@ sector = 1515;
 sidedef // 17619
 {
 sector = 1515;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17620
 {
 sector = 1516;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17621
 {
 sector = 1515;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17622
 {
 sector = 1516;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17623
 {
 sector = 1515;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17624
 {
 sector = 1516;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17625
 {
 sector = 1515;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17626
 {
 sector = 1516;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17627
 {
 sector = 1515;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17628
 {
 sector = 1516;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17629
 {
 sector = 1515;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17630
 {
 sector = 1516;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17631
 {
 sector = 1515;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17632
 {
 sector = 1516;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17633
 {
 sector = 1515;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17634
 {
 sector = 1516;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17635
 {
 sector = 1515;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17636
 {
 sector = 1516;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17637
 {
 sector = 1515;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17638
 {
 sector = 1516;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17639
 {
 sector = 1515;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17640
 {
 sector = 1516;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17641
 {
 sector = 1515;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17642
 {
 sector = 1516;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17643
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17644
@@ -303927,7 +303927,7 @@ sector = 1517;
 sidedef // 17645
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17646
@@ -303938,7 +303938,7 @@ sector = 1517;
 sidedef // 17647
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17648
@@ -303949,7 +303949,7 @@ sector = 1517;
 sidedef // 17649
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17650
@@ -303960,7 +303960,7 @@ sector = 1517;
 sidedef // 17651
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17652
@@ -303971,7 +303971,7 @@ sector = 1517;
 sidedef // 17653
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17654
@@ -303982,7 +303982,7 @@ sector = 1517;
 sidedef // 17655
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17656
@@ -303993,7 +303993,7 @@ sector = 1517;
 sidedef // 17657
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17658
@@ -304004,7 +304004,7 @@ sector = 1517;
 sidedef // 17659
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17660
@@ -304015,7 +304015,7 @@ sector = 1517;
 sidedef // 17661
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17662
@@ -304026,7 +304026,7 @@ sector = 1517;
 sidedef // 17663
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17664
@@ -304037,7 +304037,7 @@ sector = 1517;
 sidedef // 17665
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17666
@@ -304048,151 +304048,151 @@ sector = 1517;
 sidedef // 17667
 {
 sector = 1517;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17668
 {
 sector = 1518;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17669
 {
 sector = 1517;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17670
 {
 sector = 1518;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17671
 {
 sector = 1517;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17672
 {
 sector = 1518;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17673
 {
 sector = 1517;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17674
 {
 sector = 1518;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17675
 {
 sector = 1517;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17676
 {
 sector = 1518;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17677
 {
 sector = 1517;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17678
 {
 sector = 1518;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17679
 {
 sector = 1517;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17680
 {
 sector = 1518;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17681
 {
 sector = 1517;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17682
 {
 sector = 1518;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17683
 {
 sector = 1517;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17684
 {
 sector = 1518;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17685
 {
 sector = 1517;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17686
 {
 sector = 1518;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17687
 {
 sector = 1517;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17688
 {
 sector = 1518;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17689
 {
 sector = 1517;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17690
 {
 sector = 1518;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17691
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17692
@@ -304203,7 +304203,7 @@ sector = 1519;
 sidedef // 17693
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17694
@@ -304214,7 +304214,7 @@ sector = 1519;
 sidedef // 17695
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17696
@@ -304225,7 +304225,7 @@ sector = 1519;
 sidedef // 17697
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17698
@@ -304236,7 +304236,7 @@ sector = 1519;
 sidedef // 17699
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17700
@@ -304247,7 +304247,7 @@ sector = 1519;
 sidedef // 17701
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17702
@@ -304258,7 +304258,7 @@ sector = 1519;
 sidedef // 17703
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17704
@@ -304269,7 +304269,7 @@ sector = 1519;
 sidedef // 17705
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17706
@@ -304280,7 +304280,7 @@ sector = 1519;
 sidedef // 17707
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17708
@@ -304291,7 +304291,7 @@ sector = 1519;
 sidedef // 17709
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17710
@@ -304302,7 +304302,7 @@ sector = 1519;
 sidedef // 17711
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17712
@@ -304313,7 +304313,7 @@ sector = 1519;
 sidedef // 17713
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17714
@@ -304324,151 +304324,151 @@ sector = 1519;
 sidedef // 17715
 {
 sector = 1519;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17716
 {
 sector = 1520;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17717
 {
 sector = 1519;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17718
 {
 sector = 1520;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17719
 {
 sector = 1519;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17720
 {
 sector = 1520;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17721
 {
 sector = 1519;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17722
 {
 sector = 1520;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17723
 {
 sector = 1519;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17724
 {
 sector = 1520;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17725
 {
 sector = 1519;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17726
 {
 sector = 1520;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17727
 {
 sector = 1519;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17728
 {
 sector = 1520;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17729
 {
 sector = 1519;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17730
 {
 sector = 1520;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17731
 {
 sector = 1519;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17732
 {
 sector = 1520;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17733
 {
 sector = 1519;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17734
 {
 sector = 1520;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17735
 {
 sector = 1519;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17736
 {
 sector = 1520;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17737
 {
 sector = 1519;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17738
 {
 sector = 1520;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17739
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17740
@@ -304479,7 +304479,7 @@ sector = 1521;
 sidedef // 17741
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17742
@@ -304490,7 +304490,7 @@ sector = 1521;
 sidedef // 17743
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17744
@@ -304501,7 +304501,7 @@ sector = 1521;
 sidedef // 17745
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17746
@@ -304512,7 +304512,7 @@ sector = 1521;
 sidedef // 17747
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17748
@@ -304523,7 +304523,7 @@ sector = 1521;
 sidedef // 17749
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17750
@@ -304534,7 +304534,7 @@ sector = 1521;
 sidedef // 17751
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17752
@@ -304545,7 +304545,7 @@ sector = 1521;
 sidedef // 17753
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17754
@@ -304556,7 +304556,7 @@ sector = 1521;
 sidedef // 17755
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17756
@@ -304567,7 +304567,7 @@ sector = 1521;
 sidedef // 17757
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17758
@@ -304578,7 +304578,7 @@ sector = 1521;
 sidedef // 17759
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17760
@@ -304589,7 +304589,7 @@ sector = 1521;
 sidedef // 17761
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17762
@@ -304600,151 +304600,151 @@ sector = 1521;
 sidedef // 17763
 {
 sector = 1521;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17764
 {
 sector = 1522;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17765
 {
 sector = 1521;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17766
 {
 sector = 1522;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17767
 {
 sector = 1521;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17768
 {
 sector = 1522;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17769
 {
 sector = 1521;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17770
 {
 sector = 1522;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17771
 {
 sector = 1521;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17772
 {
 sector = 1522;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17773
 {
 sector = 1521;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17774
 {
 sector = 1522;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17775
 {
 sector = 1521;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17776
 {
 sector = 1522;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17777
 {
 sector = 1521;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17778
 {
 sector = 1522;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17779
 {
 sector = 1521;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17780
 {
 sector = 1522;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17781
 {
 sector = 1521;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17782
 {
 sector = 1522;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17783
 {
 sector = 1521;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17784
 {
 sector = 1522;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17785
 {
 sector = 1521;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17786
 {
 sector = 1522;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17787
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17788
@@ -304755,7 +304755,7 @@ sector = 1523;
 sidedef // 17789
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17790
@@ -304766,7 +304766,7 @@ sector = 1523;
 sidedef // 17791
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17792
@@ -304777,7 +304777,7 @@ sector = 1523;
 sidedef // 17793
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17794
@@ -304788,7 +304788,7 @@ sector = 1523;
 sidedef // 17795
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17796
@@ -304799,7 +304799,7 @@ sector = 1523;
 sidedef // 17797
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17798
@@ -304810,7 +304810,7 @@ sector = 1523;
 sidedef // 17799
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17800
@@ -304821,7 +304821,7 @@ sector = 1523;
 sidedef // 17801
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17802
@@ -304832,7 +304832,7 @@ sector = 1523;
 sidedef // 17803
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17804
@@ -304843,7 +304843,7 @@ sector = 1523;
 sidedef // 17805
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17806
@@ -304854,7 +304854,7 @@ sector = 1523;
 sidedef // 17807
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17808
@@ -304865,7 +304865,7 @@ sector = 1523;
 sidedef // 17809
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17810
@@ -304876,151 +304876,151 @@ sector = 1523;
 sidedef // 17811
 {
 sector = 1523;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17812
 {
 sector = 1524;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17813
 {
 sector = 1523;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17814
 {
 sector = 1524;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17815
 {
 sector = 1523;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17816
 {
 sector = 1524;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17817
 {
 sector = 1523;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17818
 {
 sector = 1524;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17819
 {
 sector = 1523;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17820
 {
 sector = 1524;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17821
 {
 sector = 1523;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17822
 {
 sector = 1524;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17823
 {
 sector = 1523;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17824
 {
 sector = 1524;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17825
 {
 sector = 1523;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17826
 {
 sector = 1524;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17827
 {
 sector = 1523;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17828
 {
 sector = 1524;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17829
 {
 sector = 1523;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17830
 {
 sector = 1524;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17831
 {
 sector = 1523;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17832
 {
 sector = 1524;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17833
 {
 sector = 1523;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17834
 {
 sector = 1524;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17835
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17836
@@ -305031,7 +305031,7 @@ sector = 1525;
 sidedef // 17837
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17838
@@ -305042,7 +305042,7 @@ sector = 1525;
 sidedef // 17839
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17840
@@ -305053,7 +305053,7 @@ sector = 1525;
 sidedef // 17841
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17842
@@ -305064,7 +305064,7 @@ sector = 1525;
 sidedef // 17843
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17844
@@ -305075,7 +305075,7 @@ sector = 1525;
 sidedef // 17845
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17846
@@ -305086,7 +305086,7 @@ sector = 1525;
 sidedef // 17847
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17848
@@ -305097,7 +305097,7 @@ sector = 1525;
 sidedef // 17849
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17850
@@ -305108,7 +305108,7 @@ sector = 1525;
 sidedef // 17851
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17852
@@ -305119,7 +305119,7 @@ sector = 1525;
 sidedef // 17853
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17854
@@ -305130,7 +305130,7 @@ sector = 1525;
 sidedef // 17855
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17856
@@ -305141,7 +305141,7 @@ sector = 1525;
 sidedef // 17857
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17858
@@ -305152,151 +305152,151 @@ sector = 1525;
 sidedef // 17859
 {
 sector = 1525;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17860
 {
 sector = 1526;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17861
 {
 sector = 1525;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17862
 {
 sector = 1526;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17863
 {
 sector = 1525;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17864
 {
 sector = 1526;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17865
 {
 sector = 1525;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17866
 {
 sector = 1526;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17867
 {
 sector = 1525;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17868
 {
 sector = 1526;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17869
 {
 sector = 1525;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17870
 {
 sector = 1526;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17871
 {
 sector = 1525;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17872
 {
 sector = 1526;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17873
 {
 sector = 1525;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17874
 {
 sector = 1526;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17875
 {
 sector = 1525;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17876
 {
 sector = 1526;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17877
 {
 sector = 1525;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17878
 {
 sector = 1526;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17879
 {
 sector = 1525;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17880
 {
 sector = 1526;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17881
 {
 sector = 1525;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17882
 {
 sector = 1526;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17883
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17884
@@ -305307,7 +305307,7 @@ sector = 1527;
 sidedef // 17885
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17886
@@ -305318,7 +305318,7 @@ sector = 1527;
 sidedef // 17887
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17888
@@ -305329,7 +305329,7 @@ sector = 1527;
 sidedef // 17889
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17890
@@ -305340,7 +305340,7 @@ sector = 1527;
 sidedef // 17891
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17892
@@ -305351,7 +305351,7 @@ sector = 1527;
 sidedef // 17893
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17894
@@ -305362,7 +305362,7 @@ sector = 1527;
 sidedef // 17895
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17896
@@ -305373,7 +305373,7 @@ sector = 1527;
 sidedef // 17897
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17898
@@ -305384,7 +305384,7 @@ sector = 1527;
 sidedef // 17899
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17900
@@ -305395,7 +305395,7 @@ sector = 1527;
 sidedef // 17901
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17902
@@ -305406,7 +305406,7 @@ sector = 1527;
 sidedef // 17903
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17904
@@ -305417,7 +305417,7 @@ sector = 1527;
 sidedef // 17905
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17906
@@ -305428,151 +305428,151 @@ sector = 1527;
 sidedef // 17907
 {
 sector = 1527;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17908
 {
 sector = 1528;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17909
 {
 sector = 1527;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17910
 {
 sector = 1528;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17911
 {
 sector = 1527;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17912
 {
 sector = 1528;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17913
 {
 sector = 1527;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17914
 {
 sector = 1528;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17915
 {
 sector = 1527;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17916
 {
 sector = 1528;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17917
 {
 sector = 1527;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17918
 {
 sector = 1528;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17919
 {
 sector = 1527;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17920
 {
 sector = 1528;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17921
 {
 sector = 1527;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17922
 {
 sector = 1528;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17923
 {
 sector = 1527;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17924
 {
 sector = 1528;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17925
 {
 sector = 1527;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17926
 {
 sector = 1528;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17927
 {
 sector = 1527;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17928
 {
 sector = 1528;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17929
 {
 sector = 1527;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17930
 {
 sector = 1528;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17931
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17932
@@ -305583,7 +305583,7 @@ sector = 1529;
 sidedef // 17933
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17934
@@ -305594,7 +305594,7 @@ sector = 1529;
 sidedef // 17935
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17936
@@ -305605,7 +305605,7 @@ sector = 1529;
 sidedef // 17937
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17938
@@ -305616,7 +305616,7 @@ sector = 1529;
 sidedef // 17939
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17940
@@ -305627,7 +305627,7 @@ sector = 1529;
 sidedef // 17941
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17942
@@ -305638,7 +305638,7 @@ sector = 1529;
 sidedef // 17943
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17944
@@ -305649,7 +305649,7 @@ sector = 1529;
 sidedef // 17945
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17946
@@ -305660,7 +305660,7 @@ sector = 1529;
 sidedef // 17947
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17948
@@ -305671,7 +305671,7 @@ sector = 1529;
 sidedef // 17949
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17950
@@ -305682,7 +305682,7 @@ sector = 1529;
 sidedef // 17951
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17952
@@ -305693,7 +305693,7 @@ sector = 1529;
 sidedef // 17953
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17954
@@ -305704,151 +305704,151 @@ sector = 1529;
 sidedef // 17955
 {
 sector = 1529;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17956
 {
 sector = 1530;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17957
 {
 sector = 1529;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17958
 {
 sector = 1530;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17959
 {
 sector = 1529;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17960
 {
 sector = 1530;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17961
 {
 sector = 1529;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17962
 {
 sector = 1530;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17963
 {
 sector = 1529;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17964
 {
 sector = 1530;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17965
 {
 sector = 1529;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17966
 {
 sector = 1530;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17967
 {
 sector = 1529;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17968
 {
 sector = 1530;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17969
 {
 sector = 1529;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17970
 {
 sector = 1530;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17971
 {
 sector = 1529;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17972
 {
 sector = 1530;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17973
 {
 sector = 1529;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17974
 {
 sector = 1530;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17975
 {
 sector = 1529;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17976
 {
 sector = 1530;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17977
 {
 sector = 1529;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17978
 {
 sector = 1530;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17979
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17980
@@ -305859,7 +305859,7 @@ sector = 1531;
 sidedef // 17981
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17982
@@ -305870,7 +305870,7 @@ sector = 1531;
 sidedef // 17983
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17984
@@ -305881,7 +305881,7 @@ sector = 1531;
 sidedef // 17985
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17986
@@ -305892,7 +305892,7 @@ sector = 1531;
 sidedef // 17987
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17988
@@ -305903,7 +305903,7 @@ sector = 1531;
 sidedef // 17989
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17990
@@ -305914,7 +305914,7 @@ sector = 1531;
 sidedef // 17991
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17992
@@ -305925,7 +305925,7 @@ sector = 1531;
 sidedef // 17993
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17994
@@ -305936,7 +305936,7 @@ sector = 1531;
 sidedef // 17995
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17996
@@ -305947,7 +305947,7 @@ sector = 1531;
 sidedef // 17997
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 17998
@@ -305958,7 +305958,7 @@ sector = 1531;
 sidedef // 17999
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18000
@@ -305969,7 +305969,7 @@ sector = 1531;
 sidedef // 18001
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18002
@@ -305980,151 +305980,151 @@ sector = 1531;
 sidedef // 18003
 {
 sector = 1531;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18004
 {
 sector = 1532;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18005
 {
 sector = 1531;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18006
 {
 sector = 1532;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18007
 {
 sector = 1531;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18008
 {
 sector = 1532;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18009
 {
 sector = 1531;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18010
 {
 sector = 1532;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18011
 {
 sector = 1531;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18012
 {
 sector = 1532;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18013
 {
 sector = 1531;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18014
 {
 sector = 1532;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18015
 {
 sector = 1531;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18016
 {
 sector = 1532;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18017
 {
 sector = 1531;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18018
 {
 sector = 1532;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18019
 {
 sector = 1531;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18020
 {
 sector = 1532;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18021
 {
 sector = 1531;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18022
 {
 sector = 1532;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18023
 {
 sector = 1531;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18024
 {
 sector = 1532;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18025
 {
 sector = 1531;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18026
 {
 sector = 1532;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18027
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18028
@@ -306135,7 +306135,7 @@ sector = 1533;
 sidedef // 18029
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18030
@@ -306146,7 +306146,7 @@ sector = 1533;
 sidedef // 18031
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18032
@@ -306157,7 +306157,7 @@ sector = 1533;
 sidedef // 18033
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18034
@@ -306168,7 +306168,7 @@ sector = 1533;
 sidedef // 18035
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18036
@@ -306179,7 +306179,7 @@ sector = 1533;
 sidedef // 18037
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18038
@@ -306190,7 +306190,7 @@ sector = 1533;
 sidedef // 18039
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18040
@@ -306201,7 +306201,7 @@ sector = 1533;
 sidedef // 18041
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18042
@@ -306212,7 +306212,7 @@ sector = 1533;
 sidedef // 18043
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18044
@@ -306223,7 +306223,7 @@ sector = 1533;
 sidedef // 18045
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18046
@@ -306234,7 +306234,7 @@ sector = 1533;
 sidedef // 18047
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18048
@@ -306245,7 +306245,7 @@ sector = 1533;
 sidedef // 18049
 {
 sector = 1503;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18050
@@ -306256,145 +306256,145 @@ sector = 1533;
 sidedef // 18051
 {
 sector = 1533;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18052
 {
 sector = 1534;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18053
 {
 sector = 1533;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18054
 {
 sector = 1534;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18055
 {
 sector = 1533;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18056
 {
 sector = 1534;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18057
 {
 sector = 1533;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18058
 {
 sector = 1534;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18059
 {
 sector = 1533;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18060
 {
 sector = 1534;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18061
 {
 sector = 1533;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18062
 {
 sector = 1534;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18063
 {
 sector = 1533;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18064
 {
 sector = 1534;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18065
 {
 sector = 1533;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18066
 {
 sector = 1534;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18067
 {
 sector = 1533;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18068
 {
 sector = 1534;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18069
 {
 sector = 1533;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18070
 {
 sector = 1534;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18071
 {
 sector = 1533;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18072
 {
 sector = 1534;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18073
 {
 sector = 1533;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18074
 {
 sector = 1534;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 18075
@@ -315942,7 +315942,7 @@ texturebottom = "FLAT1_1";
 sidedef // 19710
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19711
@@ -315953,7 +315953,7 @@ sector = 1636;
 sidedef // 19712
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19713
@@ -315964,7 +315964,7 @@ sector = 1636;
 sidedef // 19714
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19715
@@ -315975,7 +315975,7 @@ sector = 1636;
 sidedef // 19716
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19717
@@ -315986,7 +315986,7 @@ sector = 1636;
 sidedef // 19718
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19719
@@ -315997,7 +315997,7 @@ sector = 1636;
 sidedef // 19720
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19721
@@ -316008,7 +316008,7 @@ sector = 1636;
 sidedef // 19722
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19723
@@ -316019,7 +316019,7 @@ sector = 1636;
 sidedef // 19724
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19725
@@ -316030,7 +316030,7 @@ sector = 1636;
 sidedef // 19726
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19727
@@ -316041,7 +316041,7 @@ sector = 1636;
 sidedef // 19728
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19729
@@ -316052,7 +316052,7 @@ sector = 1636;
 sidedef // 19730
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19731
@@ -316063,7 +316063,7 @@ sector = 1636;
 sidedef // 19732
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19733
@@ -316074,151 +316074,151 @@ sector = 1636;
 sidedef // 19734
 {
 sector = 1636;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19735
 {
 sector = 1637;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19736
 {
 sector = 1636;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19737
 {
 sector = 1637;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19738
 {
 sector = 1636;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19739
 {
 sector = 1637;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19740
 {
 sector = 1636;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19741
 {
 sector = 1637;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19742
 {
 sector = 1636;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19743
 {
 sector = 1637;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19744
 {
 sector = 1636;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19745
 {
 sector = 1637;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19746
 {
 sector = 1636;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19747
 {
 sector = 1637;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19748
 {
 sector = 1636;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19749
 {
 sector = 1637;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19750
 {
 sector = 1636;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19751
 {
 sector = 1637;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19752
 {
 sector = 1636;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19753
 {
 sector = 1637;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19754
 {
 sector = 1636;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19755
 {
 sector = 1637;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19756
 {
 sector = 1636;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19757
 {
 sector = 1637;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19758
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19759
@@ -316229,7 +316229,7 @@ sector = 1638;
 sidedef // 19760
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19761
@@ -316240,7 +316240,7 @@ sector = 1638;
 sidedef // 19762
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19763
@@ -316251,7 +316251,7 @@ sector = 1638;
 sidedef // 19764
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19765
@@ -316262,7 +316262,7 @@ sector = 1638;
 sidedef // 19766
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19767
@@ -316273,7 +316273,7 @@ sector = 1638;
 sidedef // 19768
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19769
@@ -316284,7 +316284,7 @@ sector = 1638;
 sidedef // 19770
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19771
@@ -316295,7 +316295,7 @@ sector = 1638;
 sidedef // 19772
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19773
@@ -316306,7 +316306,7 @@ sector = 1638;
 sidedef // 19774
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19775
@@ -316317,7 +316317,7 @@ sector = 1638;
 sidedef // 19776
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19777
@@ -316328,7 +316328,7 @@ sector = 1638;
 sidedef // 19778
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19779
@@ -316339,7 +316339,7 @@ sector = 1638;
 sidedef // 19780
 {
 sector = 511;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19781
@@ -316350,151 +316350,151 @@ sector = 1638;
 sidedef // 19782
 {
 sector = 1638;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19783
 {
 sector = 1639;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19784
 {
 sector = 1638;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19785
 {
 sector = 1639;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19786
 {
 sector = 1638;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19787
 {
 sector = 1639;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19788
 {
 sector = 1638;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19789
 {
 sector = 1639;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19790
 {
 sector = 1638;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19791
 {
 sector = 1639;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19792
 {
 sector = 1638;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19793
 {
 sector = 1639;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19794
 {
 sector = 1638;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19795
 {
 sector = 1639;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19796
 {
 sector = 1638;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19797
 {
 sector = 1639;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19798
 {
 sector = 1638;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19799
 {
 sector = 1639;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19800
 {
 sector = 1638;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19801
 {
 sector = 1639;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19802
 {
 sector = 1638;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19803
 {
 sector = 1639;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19804
 {
 sector = 1638;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19805
 {
 sector = 1639;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19806
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19807
@@ -316505,7 +316505,7 @@ sector = 1640;
 sidedef // 19808
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19809
@@ -316516,7 +316516,7 @@ sector = 1640;
 sidedef // 19810
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19811
@@ -316527,7 +316527,7 @@ sector = 1640;
 sidedef // 19812
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19813
@@ -316538,7 +316538,7 @@ sector = 1640;
 sidedef // 19814
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19815
@@ -316549,7 +316549,7 @@ sector = 1640;
 sidedef // 19816
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19817
@@ -316560,7 +316560,7 @@ sector = 1640;
 sidedef // 19818
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19819
@@ -316571,7 +316571,7 @@ sector = 1640;
 sidedef // 19820
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19821
@@ -316582,7 +316582,7 @@ sector = 1640;
 sidedef // 19822
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19823
@@ -316593,7 +316593,7 @@ sector = 1640;
 sidedef // 19824
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19825
@@ -316604,7 +316604,7 @@ sector = 1640;
 sidedef // 19826
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19827
@@ -316615,7 +316615,7 @@ sector = 1640;
 sidedef // 19828
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19829
@@ -316626,151 +316626,151 @@ sector = 1640;
 sidedef // 19830
 {
 sector = 1640;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19831
 {
 sector = 1641;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19832
 {
 sector = 1640;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19833
 {
 sector = 1641;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19834
 {
 sector = 1640;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19835
 {
 sector = 1641;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19836
 {
 sector = 1640;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19837
 {
 sector = 1641;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19838
 {
 sector = 1640;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19839
 {
 sector = 1641;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19840
 {
 sector = 1640;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19841
 {
 sector = 1641;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19842
 {
 sector = 1640;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19843
 {
 sector = 1641;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19844
 {
 sector = 1640;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19845
 {
 sector = 1641;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19846
 {
 sector = 1640;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19847
 {
 sector = 1641;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19848
 {
 sector = 1640;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19849
 {
 sector = 1641;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19850
 {
 sector = 1640;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19851
 {
 sector = 1641;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19852
 {
 sector = 1640;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19853
 {
 sector = 1641;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19854
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19855
@@ -316781,7 +316781,7 @@ sector = 1642;
 sidedef // 19856
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19857
@@ -316792,7 +316792,7 @@ sector = 1642;
 sidedef // 19858
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19859
@@ -316803,7 +316803,7 @@ sector = 1642;
 sidedef // 19860
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19861
@@ -316814,7 +316814,7 @@ sector = 1642;
 sidedef // 19862
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19863
@@ -316825,7 +316825,7 @@ sector = 1642;
 sidedef // 19864
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19865
@@ -316836,7 +316836,7 @@ sector = 1642;
 sidedef // 19866
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19867
@@ -316847,7 +316847,7 @@ sector = 1642;
 sidedef // 19868
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19869
@@ -316858,7 +316858,7 @@ sector = 1642;
 sidedef // 19870
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19871
@@ -316869,7 +316869,7 @@ sector = 1642;
 sidedef // 19872
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19873
@@ -316880,7 +316880,7 @@ sector = 1642;
 sidedef // 19874
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19875
@@ -316891,7 +316891,7 @@ sector = 1642;
 sidedef // 19876
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19877
@@ -316902,151 +316902,151 @@ sector = 1642;
 sidedef // 19878
 {
 sector = 1642;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19879
 {
 sector = 1643;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19880
 {
 sector = 1642;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19881
 {
 sector = 1643;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19882
 {
 sector = 1642;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19883
 {
 sector = 1643;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19884
 {
 sector = 1642;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19885
 {
 sector = 1643;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19886
 {
 sector = 1642;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19887
 {
 sector = 1643;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19888
 {
 sector = 1642;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19889
 {
 sector = 1643;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19890
 {
 sector = 1642;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19891
 {
 sector = 1643;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19892
 {
 sector = 1642;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19893
 {
 sector = 1643;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19894
 {
 sector = 1642;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19895
 {
 sector = 1643;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19896
 {
 sector = 1642;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19897
 {
 sector = 1643;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19898
 {
 sector = 1642;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19899
 {
 sector = 1643;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19900
 {
 sector = 1642;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19901
 {
 sector = 1643;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19902
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19903
@@ -317057,7 +317057,7 @@ sector = 1644;
 sidedef // 19904
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19905
@@ -317068,7 +317068,7 @@ sector = 1644;
 sidedef // 19906
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19907
@@ -317079,7 +317079,7 @@ sector = 1644;
 sidedef // 19908
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19909
@@ -317090,7 +317090,7 @@ sector = 1644;
 sidedef // 19910
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19911
@@ -317101,7 +317101,7 @@ sector = 1644;
 sidedef // 19912
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19913
@@ -317112,7 +317112,7 @@ sector = 1644;
 sidedef // 19914
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19915
@@ -317123,7 +317123,7 @@ sector = 1644;
 sidedef // 19916
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19917
@@ -317134,7 +317134,7 @@ sector = 1644;
 sidedef // 19918
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19919
@@ -317145,7 +317145,7 @@ sector = 1644;
 sidedef // 19920
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19921
@@ -317156,7 +317156,7 @@ sector = 1644;
 sidedef // 19922
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19923
@@ -317167,7 +317167,7 @@ sector = 1644;
 sidedef // 19924
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19925
@@ -317178,151 +317178,151 @@ sector = 1644;
 sidedef // 19926
 {
 sector = 1644;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19927
 {
 sector = 1645;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19928
 {
 sector = 1644;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19929
 {
 sector = 1645;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19930
 {
 sector = 1644;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19931
 {
 sector = 1645;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19932
 {
 sector = 1644;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19933
 {
 sector = 1645;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19934
 {
 sector = 1644;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19935
 {
 sector = 1645;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19936
 {
 sector = 1644;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19937
 {
 sector = 1645;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19938
 {
 sector = 1644;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19939
 {
 sector = 1645;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19940
 {
 sector = 1644;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19941
 {
 sector = 1645;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19942
 {
 sector = 1644;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19943
 {
 sector = 1645;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19944
 {
 sector = 1644;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19945
 {
 sector = 1645;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19946
 {
 sector = 1644;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19947
 {
 sector = 1645;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19948
 {
 sector = 1644;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19949
 {
 sector = 1645;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19950
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19951
@@ -317333,7 +317333,7 @@ sector = 1646;
 sidedef // 19952
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19953
@@ -317344,7 +317344,7 @@ sector = 1646;
 sidedef // 19954
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19955
@@ -317355,7 +317355,7 @@ sector = 1646;
 sidedef // 19956
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19957
@@ -317366,7 +317366,7 @@ sector = 1646;
 sidedef // 19958
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19959
@@ -317377,7 +317377,7 @@ sector = 1646;
 sidedef // 19960
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19961
@@ -317388,7 +317388,7 @@ sector = 1646;
 sidedef // 19962
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19963
@@ -317399,7 +317399,7 @@ sector = 1646;
 sidedef // 19964
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19965
@@ -317410,7 +317410,7 @@ sector = 1646;
 sidedef // 19966
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19967
@@ -317421,7 +317421,7 @@ sector = 1646;
 sidedef // 19968
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19969
@@ -317432,7 +317432,7 @@ sector = 1646;
 sidedef // 19970
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19971
@@ -317443,7 +317443,7 @@ sector = 1646;
 sidedef // 19972
 {
 sector = 509;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19973
@@ -317454,145 +317454,145 @@ sector = 1646;
 sidedef // 19974
 {
 sector = 1646;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19975
 {
 sector = 1647;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19976
 {
 sector = 1646;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19977
 {
 sector = 1647;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19978
 {
 sector = 1646;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19979
 {
 sector = 1647;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19980
 {
 sector = 1646;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19981
 {
 sector = 1647;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19982
 {
 sector = 1646;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19983
 {
 sector = 1647;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19984
 {
 sector = 1646;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19985
 {
 sector = 1647;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19986
 {
 sector = 1646;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19987
 {
 sector = 1647;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19988
 {
 sector = 1646;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19989
 {
 sector = 1647;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19990
 {
 sector = 1646;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19991
 {
 sector = 1647;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19992
 {
 sector = 1646;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19993
 {
 sector = 1647;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19994
 {
 sector = 1646;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19995
 {
 sector = 1647;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19996
 {
 sector = 1646;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19997
 {
 sector = 1647;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 19998
@@ -318135,7 +318135,7 @@ texturebottom = "ASHWALL4";
 sidedef // 20086
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20087
@@ -318146,7 +318146,7 @@ sector = 1652;
 sidedef // 20088
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20089
@@ -318157,7 +318157,7 @@ sector = 1652;
 sidedef // 20090
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20091
@@ -318168,7 +318168,7 @@ sector = 1652;
 sidedef // 20092
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20093
@@ -318179,7 +318179,7 @@ sector = 1652;
 sidedef // 20094
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20095
@@ -318190,7 +318190,7 @@ sector = 1652;
 sidedef // 20096
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20097
@@ -318201,7 +318201,7 @@ sector = 1652;
 sidedef // 20098
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20099
@@ -318212,7 +318212,7 @@ sector = 1652;
 sidedef // 20100
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20101
@@ -318223,7 +318223,7 @@ sector = 1652;
 sidedef // 20102
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20103
@@ -318234,7 +318234,7 @@ sector = 1652;
 sidedef // 20104
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20105
@@ -318245,7 +318245,7 @@ sector = 1652;
 sidedef // 20106
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20107
@@ -318256,7 +318256,7 @@ sector = 1652;
 sidedef // 20108
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20109
@@ -318267,151 +318267,151 @@ sector = 1652;
 sidedef // 20110
 {
 sector = 1652;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20111
 {
 sector = 1653;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20112
 {
 sector = 1652;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20113
 {
 sector = 1653;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20114
 {
 sector = 1652;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20115
 {
 sector = 1653;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20116
 {
 sector = 1652;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20117
 {
 sector = 1653;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20118
 {
 sector = 1652;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20119
 {
 sector = 1653;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20120
 {
 sector = 1652;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20121
 {
 sector = 1653;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20122
 {
 sector = 1652;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20123
 {
 sector = 1653;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20124
 {
 sector = 1652;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20125
 {
 sector = 1653;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20126
 {
 sector = 1652;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20127
 {
 sector = 1653;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20128
 {
 sector = 1652;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20129
 {
 sector = 1653;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20130
 {
 sector = 1652;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20131
 {
 sector = 1653;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20132
 {
 sector = 1652;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20133
 {
 sector = 1653;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20134
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20135
@@ -318422,7 +318422,7 @@ sector = 1654;
 sidedef // 20136
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20137
@@ -318433,7 +318433,7 @@ sector = 1654;
 sidedef // 20138
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20139
@@ -318444,7 +318444,7 @@ sector = 1654;
 sidedef // 20140
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20141
@@ -318455,7 +318455,7 @@ sector = 1654;
 sidedef // 20142
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20143
@@ -318466,7 +318466,7 @@ sector = 1654;
 sidedef // 20144
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20145
@@ -318477,7 +318477,7 @@ sector = 1654;
 sidedef // 20146
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20147
@@ -318488,7 +318488,7 @@ sector = 1654;
 sidedef // 20148
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20149
@@ -318499,7 +318499,7 @@ sector = 1654;
 sidedef // 20150
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20151
@@ -318510,7 +318510,7 @@ sector = 1654;
 sidedef // 20152
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20153
@@ -318521,7 +318521,7 @@ sector = 1654;
 sidedef // 20154
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20155
@@ -318532,7 +318532,7 @@ sector = 1654;
 sidedef // 20156
 {
 sector = 1620;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20157
@@ -318543,145 +318543,145 @@ sector = 1654;
 sidedef // 20158
 {
 sector = 1654;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20159
 {
 sector = 1655;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20160
 {
 sector = 1654;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20161
 {
 sector = 1655;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20162
 {
 sector = 1654;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20163
 {
 sector = 1655;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20164
 {
 sector = 1654;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20165
 {
 sector = 1655;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20166
 {
 sector = 1654;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20167
 {
 sector = 1655;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20168
 {
 sector = 1654;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20169
 {
 sector = 1655;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20170
 {
 sector = 1654;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20171
 {
 sector = 1655;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20172
 {
 sector = 1654;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20173
 {
 sector = 1655;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20174
 {
 sector = 1654;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20175
 {
 sector = 1655;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20176
 {
 sector = 1654;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20177
 {
 sector = 1655;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20178
 {
 sector = 1654;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20179
 {
 sector = 1655;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20180
 {
 sector = 1654;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20181
 {
 sector = 1655;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 20182
@@ -346593,7 +346593,7 @@ sector // 557
 heightfloor = 600;
 heightceiling = 808;
 texturefloor = "SLIME15";
-textureceiling = "SUPPORT2";
+textureceiling = "SUPPORT4";
 lightlevel = 255;
 }
 
@@ -346612,7 +346612,7 @@ sector // 559
 heightfloor = 600;
 heightceiling = 808;
 texturefloor = "SLIME15";
-textureceiling = "SUPPORT2";
+textureceiling = "SUPPORT4";
 lightlevel = 255;
 }
 
@@ -346630,7 +346630,7 @@ sector // 561
 heightfloor = 600;
 heightceiling = 808;
 texturefloor = "SLIME15";
-textureceiling = "SUPPORT2";
+textureceiling = "SUPPORT4";
 lightlevel = 255;
 }
 
@@ -346639,7 +346639,7 @@ sector // 562
 heightfloor = 600;
 heightceiling = 808;
 texturefloor = "SLIME15";
-textureceiling = "SUPPORT2";
+textureceiling = "SUPPORT4";
 lightlevel = 255;
 }
 
@@ -355362,7 +355362,7 @@ sector // 1509
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -355380,7 +355380,7 @@ sector // 1511
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -355398,7 +355398,7 @@ sector // 1513
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -355425,7 +355425,7 @@ sector // 1516
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -355443,7 +355443,7 @@ sector // 1518
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -355461,7 +355461,7 @@ sector // 1520
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -355479,7 +355479,7 @@ sector // 1522
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -355497,7 +355497,7 @@ sector // 1524
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -355515,7 +355515,7 @@ sector // 1526
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -355533,7 +355533,7 @@ sector // 1528
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -355551,7 +355551,7 @@ sector // 1530
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -355569,7 +355569,7 @@ sector // 1532
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -355587,7 +355587,7 @@ sector // 1534
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -356533,7 +356533,7 @@ sector // 1637
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -356551,7 +356551,7 @@ sector // 1639
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -356569,7 +356569,7 @@ sector // 1641
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -356587,7 +356587,7 @@ sector // 1643
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -356605,7 +356605,7 @@ sector // 1645
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -356623,7 +356623,7 @@ sector // 1647
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -356678,7 +356678,7 @@ sector // 1653
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -356696,7 +356696,7 @@ sector // 1655
 {
 heightfloor = 0;
 heightceiling = 504;
-texturefloor = "SUPPORT2";
+texturefloor = "SUPPORT4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }

--- a/mapsrc/ZombieHorde2Legacy/ZM18/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM18/TEXTMAP
@@ -150981,7 +150981,7 @@ sector = 402;
 sidedef // 2592
 {
 sector = 1501;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 2593
@@ -151003,7 +151003,7 @@ sector = 402;
 sidedef // 2596
 {
 sector = 1501;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 2597
@@ -151014,7 +151014,7 @@ sector = 402;
 sidedef // 2598
 {
 sector = 1501;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 2599
@@ -151025,7 +151025,7 @@ sector = 403;
 sidedef // 2600
 {
 sector = 1501;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 2601
@@ -151036,7 +151036,7 @@ sector = 403;
 sidedef // 2602
 {
 sector = 1501;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 2603
@@ -151047,7 +151047,7 @@ sector = 403;
 sidedef // 2604
 {
 sector = 1501;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 2605
@@ -151058,7 +151058,7 @@ sector = 404;
 sidedef // 2606
 {
 sector = 1501;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 2607
@@ -151128,7 +151128,7 @@ sector = 406;
 sidedef // 2618
 {
 sector = 131;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 2619
@@ -151150,7 +151150,7 @@ sector = 406;
 sidedef // 2622
 {
 sector = 131;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 2623
@@ -151161,7 +151161,7 @@ sector = 406;
 sidedef // 2624
 {
 sector = 131;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 2625
@@ -151172,7 +151172,7 @@ sector = 407;
 sidedef // 2626
 {
 sector = 131;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 2627
@@ -151183,7 +151183,7 @@ sector = 407;
 sidedef // 2628
 {
 sector = 131;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 2629
@@ -151194,7 +151194,7 @@ sector = 407;
 sidedef // 2630
 {
 sector = 131;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 2631
@@ -151205,7 +151205,7 @@ sector = 408;
 sidedef // 2632
 {
 sector = 131;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 2633
@@ -153797,7 +153797,7 @@ sector = 442;
 sidedef // 3043
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3044
@@ -153819,7 +153819,7 @@ sector = 442;
 sidedef // 3047
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3048
@@ -153830,7 +153830,7 @@ sector = 442;
 sidedef // 3049
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3050
@@ -153841,7 +153841,7 @@ sector = 443;
 sidedef // 3051
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3052
@@ -153852,7 +153852,7 @@ sector = 443;
 sidedef // 3053
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3054
@@ -153863,7 +153863,7 @@ sector = 443;
 sidedef // 3055
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3056
@@ -153874,7 +153874,7 @@ sector = 444;
 sidedef // 3057
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3058
@@ -153906,7 +153906,7 @@ sector = 445;
 sidedef // 3063
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3064
@@ -153928,7 +153928,7 @@ sector = 445;
 sidedef // 3067
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3068
@@ -153939,7 +153939,7 @@ sector = 445;
 sidedef // 3069
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3070
@@ -153950,7 +153950,7 @@ sector = 446;
 sidedef // 3071
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3072
@@ -153961,7 +153961,7 @@ sector = 446;
 sidedef // 3073
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3074
@@ -153972,7 +153972,7 @@ sector = 446;
 sidedef // 3075
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3076
@@ -153983,7 +153983,7 @@ sector = 447;
 sidedef // 3077
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3078
@@ -154015,7 +154015,7 @@ sector = 448;
 sidedef // 3083
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3084
@@ -154037,7 +154037,7 @@ sector = 448;
 sidedef // 3087
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3088
@@ -154048,7 +154048,7 @@ sector = 448;
 sidedef // 3089
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3090
@@ -154059,7 +154059,7 @@ sector = 449;
 sidedef // 3091
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3092
@@ -154070,7 +154070,7 @@ sector = 449;
 sidedef // 3093
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3094
@@ -154081,7 +154081,7 @@ sector = 449;
 sidedef // 3095
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3096
@@ -154092,7 +154092,7 @@ sector = 450;
 sidedef // 3097
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3098
@@ -154124,7 +154124,7 @@ sector = 451;
 sidedef // 3103
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3104
@@ -154146,7 +154146,7 @@ sector = 451;
 sidedef // 3107
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3108
@@ -154157,7 +154157,7 @@ sector = 451;
 sidedef // 3109
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3110
@@ -154168,7 +154168,7 @@ sector = 452;
 sidedef // 3111
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3112
@@ -154179,7 +154179,7 @@ sector = 452;
 sidedef // 3113
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3114
@@ -154190,7 +154190,7 @@ sector = 452;
 sidedef // 3115
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3116
@@ -154201,7 +154201,7 @@ sector = 453;
 sidedef // 3117
 {
 sector = 303;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3118
@@ -155641,7 +155641,7 @@ sector = 488;
 sidedef // 3366
 {
 sector = 1498;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3367
@@ -155663,7 +155663,7 @@ sector = 488;
 sidedef // 3370
 {
 sector = 1498;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3371
@@ -155674,7 +155674,7 @@ sector = 488;
 sidedef // 3372
 {
 sector = 1498;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3373
@@ -155685,7 +155685,7 @@ sector = 489;
 sidedef // 3374
 {
 sector = 1498;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3375
@@ -155696,7 +155696,7 @@ sector = 489;
 sidedef // 3376
 {
 sector = 1498;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3377
@@ -155707,7 +155707,7 @@ sector = 489;
 sidedef // 3378
 {
 sector = 1498;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3379
@@ -155718,7 +155718,7 @@ sector = 490;
 sidedef // 3380
 {
 sector = 1498;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3381
@@ -156496,7 +156496,7 @@ sector = 333;
 sidedef // 3516
 {
 sector = 499;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3517
@@ -156507,7 +156507,7 @@ sector = 508;
 sidedef // 3518
 {
 sector = 499;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3519
@@ -156518,7 +156518,7 @@ sector = 506;
 sidedef // 3520
 {
 sector = 499;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3521
@@ -156529,7 +156529,7 @@ sector = 508;
 sidedef // 3522
 {
 sector = 499;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3523
@@ -156561,7 +156561,7 @@ sector = 508;
 sidedef // 3528
 {
 sector = 499;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3529
@@ -156572,7 +156572,7 @@ sector = 507;
 sidedef // 3530
 {
 sector = 499;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3531
@@ -156594,7 +156594,7 @@ sector = 508;
 sidedef // 3534
 {
 sector = 499;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 3535
@@ -167279,7 +167279,7 @@ sector = 705;
 sidedef // 5313
 {
 sector = 704;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 5314
@@ -167301,7 +167301,7 @@ sector = 705;
 sidedef // 5317
 {
 sector = 704;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 5318
@@ -167312,7 +167312,7 @@ sector = 705;
 sidedef // 5319
 {
 sector = 704;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 5320
@@ -167323,7 +167323,7 @@ sector = 706;
 sidedef // 5321
 {
 sector = 704;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 5322
@@ -167334,7 +167334,7 @@ sector = 706;
 sidedef // 5323
 {
 sector = 704;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 5324
@@ -167345,7 +167345,7 @@ sector = 706;
 sidedef // 5325
 {
 sector = 704;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 5326
@@ -167356,7 +167356,7 @@ sector = 707;
 sidedef // 5327
 {
 sector = 704;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 5328
@@ -178879,7 +178879,7 @@ sector = 961;
 sidedef // 7346
 {
 sector = 220;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7347
@@ -178901,7 +178901,7 @@ sector = 961;
 sidedef // 7350
 {
 sector = 220;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7351
@@ -178912,7 +178912,7 @@ sector = 961;
 sidedef // 7352
 {
 sector = 220;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7353
@@ -178923,7 +178923,7 @@ sector = 962;
 sidedef // 7354
 {
 sector = 220;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7355
@@ -178934,7 +178934,7 @@ sector = 962;
 sidedef // 7356
 {
 sector = 220;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7357
@@ -178945,7 +178945,7 @@ sector = 962;
 sidedef // 7358
 {
 sector = 220;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7359
@@ -178956,7 +178956,7 @@ sector = 963;
 sidedef // 7360
 {
 sector = 220;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7361
@@ -179026,7 +179026,7 @@ sector = 965;
 sidedef // 7372
 {
 sector = 220;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7373
@@ -179048,7 +179048,7 @@ sector = 965;
 sidedef // 7376
 {
 sector = 220;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7377
@@ -179059,7 +179059,7 @@ sector = 965;
 sidedef // 7378
 {
 sector = 220;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7379
@@ -179070,7 +179070,7 @@ sector = 966;
 sidedef // 7380
 {
 sector = 220;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7381
@@ -179081,7 +179081,7 @@ sector = 966;
 sidedef // 7382
 {
 sector = 220;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7383
@@ -179092,7 +179092,7 @@ sector = 966;
 sidedef // 7384
 {
 sector = 220;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7385
@@ -179103,7 +179103,7 @@ sector = 967;
 sidedef // 7386
 {
 sector = 220;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7387
@@ -179173,7 +179173,7 @@ sector = 969;
 sidedef // 7398
 {
 sector = 1494;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7399
@@ -179195,7 +179195,7 @@ sector = 969;
 sidedef // 7402
 {
 sector = 1494;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7403
@@ -179206,7 +179206,7 @@ sector = 969;
 sidedef // 7404
 {
 sector = 1494;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7405
@@ -179217,7 +179217,7 @@ sector = 970;
 sidedef // 7406
 {
 sector = 1494;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7407
@@ -179228,7 +179228,7 @@ sector = 970;
 sidedef // 7408
 {
 sector = 1494;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7409
@@ -179239,7 +179239,7 @@ sector = 970;
 sidedef // 7410
 {
 sector = 1494;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7411
@@ -179250,7 +179250,7 @@ sector = 971;
 sidedef // 7412
 {
 sector = 1494;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7413
@@ -179320,7 +179320,7 @@ sector = 973;
 sidedef // 7424
 {
 sector = 1494;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7425
@@ -179342,7 +179342,7 @@ sector = 973;
 sidedef // 7428
 {
 sector = 1494;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7429
@@ -179353,7 +179353,7 @@ sector = 973;
 sidedef // 7430
 {
 sector = 1494;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7431
@@ -179364,7 +179364,7 @@ sector = 974;
 sidedef // 7432
 {
 sector = 1494;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7433
@@ -179375,7 +179375,7 @@ sector = 974;
 sidedef // 7434
 {
 sector = 1494;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7435
@@ -179386,7 +179386,7 @@ sector = 974;
 sidedef // 7436
 {
 sector = 1494;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7437
@@ -179397,7 +179397,7 @@ sector = 975;
 sidedef // 7438
 {
 sector = 1494;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7439
@@ -179462,7 +179462,7 @@ sector = 977;
 sidedef // 7449
 {
 sector = 1472;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7450
@@ -179484,7 +179484,7 @@ sector = 977;
 sidedef // 7453
 {
 sector = 1472;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7454
@@ -179495,7 +179495,7 @@ sector = 977;
 sidedef // 7455
 {
 sector = 1472;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7456
@@ -179506,7 +179506,7 @@ sector = 978;
 sidedef // 7457
 {
 sector = 1472;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7458
@@ -179517,7 +179517,7 @@ sector = 978;
 sidedef // 7459
 {
 sector = 1472;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7460
@@ -179528,7 +179528,7 @@ sector = 978;
 sidedef // 7461
 {
 sector = 1472;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7462
@@ -179539,7 +179539,7 @@ sector = 979;
 sidedef // 7463
 {
 sector = 1472;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 7464
@@ -186768,7 +186768,7 @@ sidedef // 8728
 {
 sector = 1044;
 offsetx = 24;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 8729
@@ -189734,7 +189734,7 @@ sector = 1165;
 sidedef // 9243
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9244
@@ -189756,7 +189756,7 @@ sector = 1165;
 sidedef // 9247
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9248
@@ -189767,7 +189767,7 @@ sector = 1165;
 sidedef // 9249
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9250
@@ -189791,7 +189791,7 @@ sector = 1191;
 sidedef // 9253
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9254
@@ -189802,7 +189802,7 @@ sector = 1166;
 sidedef // 9255
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9256
@@ -189813,7 +189813,7 @@ sector = 1167;
 sidedef // 9257
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9258
@@ -189845,7 +189845,7 @@ sector = 1168;
 sidedef // 9263
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9264
@@ -189867,7 +189867,7 @@ sector = 1168;
 sidedef // 9267
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9268
@@ -189878,7 +189878,7 @@ sector = 1168;
 sidedef // 9269
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9270
@@ -189895,7 +189895,7 @@ texturemiddle = "SILVER1";
 sidedef // 9272
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9273
@@ -189906,7 +189906,7 @@ sector = 1169;
 sidedef // 9274
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9275
@@ -189917,7 +189917,7 @@ sector = 1170;
 sidedef // 9276
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9277
@@ -189949,7 +189949,7 @@ sector = 1171;
 sidedef // 9282
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9283
@@ -189971,7 +189971,7 @@ sector = 1171;
 sidedef // 9286
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9287
@@ -189982,7 +189982,7 @@ sector = 1171;
 sidedef // 9288
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9289
@@ -190000,7 +190000,7 @@ texturemiddle = "SILVER1";
 sidedef // 9291
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9292
@@ -190011,7 +190011,7 @@ sector = 1172;
 sidedef // 9293
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9294
@@ -190022,7 +190022,7 @@ sector = 1173;
 sidedef // 9295
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9296
@@ -190054,7 +190054,7 @@ sector = 1174;
 sidedef // 9301
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9302
@@ -190076,7 +190076,7 @@ sector = 1174;
 sidedef // 9305
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9306
@@ -190087,7 +190087,7 @@ sector = 1174;
 sidedef // 9307
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9308
@@ -190110,7 +190110,7 @@ sector = 1190;
 sidedef // 9311
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9312
@@ -190121,7 +190121,7 @@ sector = 1175;
 sidedef // 9313
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9314
@@ -190132,7 +190132,7 @@ sector = 1176;
 sidedef // 9315
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9316
@@ -190164,7 +190164,7 @@ sector = 1177;
 sidedef // 9321
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9322
@@ -190186,7 +190186,7 @@ sector = 1177;
 sidedef // 9325
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9326
@@ -190197,7 +190197,7 @@ sector = 1177;
 sidedef // 9327
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9328
@@ -190208,7 +190208,7 @@ sector = 1178;
 sidedef // 9329
 {
 sector = 1467;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9330
@@ -190219,7 +190219,7 @@ sector = 1169;
 sidedef // 9331
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9332
@@ -190230,7 +190230,7 @@ sector = 1178;
 sidedef // 9333
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9334
@@ -190241,7 +190241,7 @@ sector = 1179;
 sidedef // 9335
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9336
@@ -190273,7 +190273,7 @@ sector = 1180;
 sidedef // 9341
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9342
@@ -190295,7 +190295,7 @@ sector = 1180;
 sidedef // 9345
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9346
@@ -190306,7 +190306,7 @@ sector = 1180;
 sidedef // 9347
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9348
@@ -190317,7 +190317,7 @@ sector = 1181;
 sidedef // 9349
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9350
@@ -190328,7 +190328,7 @@ sector = 1181;
 sidedef // 9351
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9352
@@ -190339,7 +190339,7 @@ sector = 1181;
 sidedef // 9353
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9354
@@ -190350,7 +190350,7 @@ sector = 1182;
 sidedef // 9355
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9356
@@ -190382,7 +190382,7 @@ sector = 1183;
 sidedef // 9361
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9362
@@ -190404,7 +190404,7 @@ sector = 1183;
 sidedef // 9365
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9366
@@ -190415,7 +190415,7 @@ sector = 1183;
 sidedef // 9367
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9368
@@ -190426,7 +190426,7 @@ sector = 1184;
 sidedef // 9369
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9370
@@ -190437,7 +190437,7 @@ sector = 1184;
 sidedef // 9371
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9372
@@ -190448,7 +190448,7 @@ sector = 1184;
 sidedef // 9373
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9374
@@ -190459,7 +190459,7 @@ sector = 1185;
 sidedef // 9375
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9376
@@ -190491,7 +190491,7 @@ sector = 1186;
 sidedef // 9381
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9382
@@ -190513,7 +190513,7 @@ sector = 1186;
 sidedef // 9385
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9386
@@ -190524,7 +190524,7 @@ sector = 1186;
 sidedef // 9387
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9388
@@ -190535,7 +190535,7 @@ sector = 1187;
 sidedef // 9389
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9390
@@ -190546,7 +190546,7 @@ sector = 1187;
 sidedef // 9391
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9392
@@ -190557,7 +190557,7 @@ sector = 1187;
 sidedef // 9393
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9394
@@ -190568,7 +190568,7 @@ sector = 1188;
 sidedef // 9395
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9396
@@ -190643,7 +190643,7 @@ sidedef // 9408
 sector = 1466;
 offsetx = 376;
 texturetop = "SILVER1";
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9409
@@ -190715,7 +190715,7 @@ sector = 1467;
 sidedef // 9421
 {
 sector = 1467;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 9422
@@ -194841,7 +194841,7 @@ texturemiddle = "SILVER1";
 sidedef // 10129
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10130
@@ -194862,7 +194862,7 @@ sector = 1291;
 sidedef // 10133
 {
 sector = 1291;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10134
@@ -194873,7 +194873,7 @@ sector = 1288;
 sidedef // 10135
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10136
@@ -194884,7 +194884,7 @@ sector = 1287;
 sidedef // 10137
 {
 sector = 1291;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10138
@@ -194905,7 +194905,7 @@ sector = 1291;
 sidedef // 10141
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10142
@@ -194916,7 +194916,7 @@ sector = 1288;
 sidedef // 10143
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10144
@@ -194927,7 +194927,7 @@ sector = 1288;
 sidedef // 10145
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10146
@@ -194938,7 +194938,7 @@ sector = 1289;
 sidedef // 10147
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10148
@@ -194959,7 +194959,7 @@ sector = 1291;
 sidedef // 10151
 {
 sector = 1291;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10152
@@ -194970,7 +194970,7 @@ sector = 1290;
 sidedef // 10153
 {
 sector = 1291;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10154
@@ -194981,7 +194981,7 @@ sector = 1287;
 sidedef // 10155
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10156
@@ -194992,7 +194992,7 @@ sector = 1290;
 sidedef // 10157
 {
 sector = 1047;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10158
@@ -195003,7 +195003,7 @@ sector = 1290;
 sidedef // 10159
 {
 sector = 1291;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10160
@@ -195019,13 +195019,13 @@ sector = 1289;
 sidedef // 10162
 {
 sector = 1291;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10163
 {
 sector = 1291;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10164
@@ -195046,7 +195046,7 @@ sector = 1291;
 sidedef // 10167
 {
 sector = 1291;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 10168
@@ -202795,7 +202795,7 @@ texturemiddle = "SHAWN2";
 sidedef // 11466
 {
 sector = 1462;
-texturemiddle = "SUPPORT2";
+texturemiddle = "support4";
 }
 
 sidedef // 11467
@@ -202839,7 +202839,7 @@ sidedef // 11473
 {
 sector = 1462;
 offsetx = 128;
-texturemiddle = "SUPPORT2";
+texturemiddle = "support4";
 }
 
 sidedef // 11474
@@ -202856,7 +202856,7 @@ sector = 1462;
 sidedef // 11476
 {
 sector = 1464;
-texturemiddle = "SUPPORT2";
+texturemiddle = "support4";
 }
 
 sidedef // 11477
@@ -202893,7 +202893,7 @@ sidedef // 11482
 {
 sector = 1464;
 offsetx = 128;
-texturemiddle = "SUPPORT2";
+texturemiddle = "support4";
 }
 
 sidedef // 11483
@@ -202982,7 +202982,7 @@ sector = 1467;
 sidedef // 11498
 {
 sector = 1467;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 11499
@@ -203003,7 +203003,7 @@ sector = 1467;
 sidedef // 11502
 {
 sector = 1467;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 11503
@@ -203024,7 +203024,7 @@ sector = 1467;
 sidedef // 11506
 {
 sector = 1467;
-texturebottom = "SUPPORT2";
+texturebottom = "support4";
 }
 
 sidedef // 11507
@@ -213359,7 +213359,7 @@ sector // 402
 {
 heightfloor = 64;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -213368,7 +213368,7 @@ sector // 403
 {
 heightfloor = 16;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -213377,7 +213377,7 @@ sector // 404
 {
 heightfloor = 64;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -213395,7 +213395,7 @@ sector // 406
 {
 heightfloor = 64;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 id = 3;
@@ -213405,7 +213405,7 @@ sector // 407
 {
 heightfloor = 16;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 id = 3;
@@ -213415,7 +213415,7 @@ sector // 408
 {
 heightfloor = 64;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 id = 3;
@@ -213724,7 +213724,7 @@ sector // 442
 {
 heightfloor = -64;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -213733,7 +213733,7 @@ sector // 443
 {
 heightfloor = -112;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -213742,7 +213742,7 @@ sector // 444
 {
 heightfloor = -64;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -213751,7 +213751,7 @@ sector // 445
 {
 heightfloor = -64;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -213760,7 +213760,7 @@ sector // 446
 {
 heightfloor = -112;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -213769,7 +213769,7 @@ sector // 447
 {
 heightfloor = -64;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -213778,7 +213778,7 @@ sector // 448
 {
 heightfloor = -64;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -213787,7 +213787,7 @@ sector // 449
 {
 heightfloor = -112;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -213796,7 +213796,7 @@ sector // 450
 {
 heightfloor = -64;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -213805,7 +213805,7 @@ sector // 451
 {
 heightfloor = -64;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -213814,7 +213814,7 @@ sector // 452
 {
 heightfloor = -112;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -213823,7 +213823,7 @@ sector // 453
 {
 heightfloor = -64;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -214165,7 +214165,7 @@ sector // 488
 {
 heightfloor = -192;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 id = 16;
@@ -214175,7 +214175,7 @@ sector // 489
 {
 heightfloor = -240;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 id = 16;
@@ -214185,7 +214185,7 @@ sector // 490
 {
 heightfloor = -192;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 id = 16;
@@ -214345,7 +214345,7 @@ sector // 506
 {
 heightfloor = -240;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 id = 16;
@@ -214355,7 +214355,7 @@ sector // 507
 {
 heightfloor = -192;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 id = 16;
@@ -214365,7 +214365,7 @@ sector // 508
 {
 heightfloor = -192;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 id = 16;
@@ -216177,7 +216177,7 @@ sector // 705
 {
 heightfloor = -64;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -216186,7 +216186,7 @@ sector // 706
 {
 heightfloor = -112;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -216195,7 +216195,7 @@ sector // 707
 {
 heightfloor = -64;
 heightceiling = 0;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 80;
 }
@@ -218524,7 +218524,7 @@ sector // 961
 {
 heightfloor = 64;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -218533,7 +218533,7 @@ sector // 962
 {
 heightfloor = 16;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -218542,7 +218542,7 @@ sector // 963
 {
 heightfloor = 64;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -218560,7 +218560,7 @@ sector // 965
 {
 heightfloor = 64;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -218569,7 +218569,7 @@ sector // 966
 {
 heightfloor = 16;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -218578,7 +218578,7 @@ sector // 967
 {
 heightfloor = 64;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -218596,7 +218596,7 @@ sector // 969
 {
 heightfloor = 64;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -218605,7 +218605,7 @@ sector // 970
 {
 heightfloor = 16;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -218614,7 +218614,7 @@ sector // 971
 {
 heightfloor = 64;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -218632,7 +218632,7 @@ sector // 973
 {
 heightfloor = 64;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -218641,7 +218641,7 @@ sector // 974
 {
 heightfloor = 16;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -218650,7 +218650,7 @@ sector // 975
 {
 heightfloor = 64;
 heightceiling = 256;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -218668,7 +218668,7 @@ sector // 977
 {
 heightfloor = 64;
 heightceiling = 320;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -218677,7 +218677,7 @@ sector // 978
 {
 heightfloor = 16;
 heightceiling = 320;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -218686,7 +218686,7 @@ sector // 979
 {
 heightfloor = 64;
 heightceiling = 320;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "FLAT14-Y";
 lightlevel = 110;
 }
@@ -220376,7 +220376,7 @@ sector // 1165
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220385,7 +220385,7 @@ sector // 1166
 {
 heightfloor = 144;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220394,7 +220394,7 @@ sector // 1167
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220403,7 +220403,7 @@ sector // 1168
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220412,7 +220412,7 @@ sector // 1169
 {
 heightfloor = 144;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220421,7 +220421,7 @@ sector // 1170
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220430,7 +220430,7 @@ sector // 1171
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220439,7 +220439,7 @@ sector // 1172
 {
 heightfloor = 144;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220448,7 +220448,7 @@ sector // 1173
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220457,7 +220457,7 @@ sector // 1174
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220466,7 +220466,7 @@ sector // 1175
 {
 heightfloor = 144;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220475,7 +220475,7 @@ sector // 1176
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220484,7 +220484,7 @@ sector // 1177
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220493,7 +220493,7 @@ sector // 1178
 {
 heightfloor = 144;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220502,7 +220502,7 @@ sector // 1179
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220511,7 +220511,7 @@ sector // 1180
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220520,7 +220520,7 @@ sector // 1181
 {
 heightfloor = 144;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220529,7 +220529,7 @@ sector // 1182
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220538,7 +220538,7 @@ sector // 1183
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220547,7 +220547,7 @@ sector // 1184
 {
 heightfloor = 144;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220556,7 +220556,7 @@ sector // 1185
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220565,7 +220565,7 @@ sector // 1186
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220574,7 +220574,7 @@ sector // 1187
 {
 heightfloor = 144;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -220583,7 +220583,7 @@ sector // 1188
 {
 heightfloor = 192;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -221475,7 +221475,7 @@ sector // 1286
 {
 heightfloor = 384;
 heightceiling = 384;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "RWALL14";
 lightlevel = 130;
 }
@@ -221484,7 +221484,7 @@ sector // 1287
 {
 heightfloor = 384;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -221493,7 +221493,7 @@ sector // 1288
 {
 heightfloor = 384;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -221502,7 +221502,7 @@ sector // 1289
 {
 heightfloor = 384;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }
@@ -221511,7 +221511,7 @@ sector // 1290
 {
 heightfloor = 384;
 heightceiling = 512;
-texturefloor = "SUPPORT2";
+texturefloor = "support4";
 textureceiling = "F_SKY1";
 lightlevel = 130;
 }

--- a/mapsrc/ZombieHorde2Legacy/ZM22/TEXTMAP
+++ b/mapsrc/ZombieHorde2Legacy/ZM22/TEXTMAP
@@ -137916,7 +137916,7 @@ offsetx = 128;
 sidedef // 1594
 {
 sector = 187;
-texturebottom = "SUPPORT2";
+texturebottom = "SUPPORT4";
 }
 
 sidedef // 1595


### PR DESCRIPTION
Unforseen consequences of #73 .
Some maps used the dup version of SUPPORT2 and needed to be ported to SUPPORT4 texture.