### PR TITLE
IdentifyPlayers extensions

### DIFF
--- a/docs/patchnotes/zh2_beta_v5.0.0_patchnotes.txt
+++ b/docs/patchnotes/zh2_beta_v5.0.0_patchnotes.txt
@@ -1,4 +1,15 @@
-MAP changes
+New features
+------------------------------------------------
+
+ * * Identify player improvements * *
+Improvements have been made tot he identify player system!
+Server owners can now manage the feature globally with a new cvar `sv_zh2_identifyplayers`. By setting it to `false` you can turn it off.
+Clients now have two new additions to the identify player feature.
+First of all, enabling it can now optionally be based on the player's specie. CVar `cl_zh2_identifyplayers` now supports two more values indicating if we enable it for the same species, or other species specifically.
+Secondly, players can now also manage what to show by configuring `cl_zh2_identifyplayertype`. With this CVar you can configure if you want to show names, species, or both.
+This puts the feature more in line with new features in general and provides more control to players to configure it exactly how they want.
+
+Map changes
 ------------------------------------------------
 
 - [ZE24]:  Korax and D'Sparil now chat using the new `Chat` namespace instead of through logging.

--- a/pk3/ZombieHorde2/acs_source/zh2game/cvars.acs
+++ b/pk3/ZombieHorde2/acs_source/zh2game/cvars.acs
@@ -62,7 +62,9 @@ strict namespace ZH2Game
     // Player
     internal int GetShownInventoryItems() { return BCSUTILS::Clamp(GetCvar("cl_zh2_showninventoryitems"), 1, 11); }
     internal bool GetWrapInventoryItems() { return (bool)GetCvar("cl_zh2_wrapinventoryitems"); }
-    internal bool GetIdentifyPlayers() { return (bool)GetCvar("cl_zh2_identifyplayers"); }
+
+    internal bool GetClIdentifyPlayers() { return (bool)GetCvar("cl_zh2_identifyplayers"); }
+    internal bool GetSvIdentifyPlayers() { return (bool)GetCvar("sv_zh2_identifyplayers"); }
 
     internal bool GetAutoUseMedikits(int playerId) { return (bool)GetUserCvar(playerId, "cl_zh2_autousemedikits"); }
     internal bool GetAutoUseKevlars(int playerId) { return (bool)GetUserCvar(playerId, "cl_zh2_autousekevlars"); }

--- a/pk3/ZombieHorde2/acs_source/zh2game/cvars.acs
+++ b/pk3/ZombieHorde2/acs_source/zh2game/cvars.acs
@@ -63,8 +63,21 @@ strict namespace ZH2Game
     internal int GetShownInventoryItems() { return BCSUTILS::Clamp(GetCvar("cl_zh2_showninventoryitems"), 1, 11); }
     internal bool GetWrapInventoryItems() { return (bool)GetCvar("cl_zh2_wrapinventoryitems"); }
 
-    internal bool GetClIdentifyPlayers() { return (bool)GetCvar("cl_zh2_identifyplayers"); }
     internal bool GetSvIdentifyPlayers() { return (bool)GetCvar("sv_zh2_identifyplayers"); }
+    internal IdentifyPlayerSpecieTypeT GetClIdentifyPlayers()
+    {
+        switch (BCSUTILS::Clamp(GetCVar("cl_zh2_identifyplayers"), 0, 3))
+        {
+            case 1:
+                return IDENTIFY_PLAYER_ALL;
+            case 2:
+                return IDENTIFY_PLAYER_ONLY_SAME;
+            case 3:
+                return IDENTIFY_PLAYER_ONLY_OTHER;
+            default:
+                return IDENTIFY_PLAYER_OFF;
+        }
+    }
     internal IdentifyPlayerTypeT GetClIdentifyPlayerType()
     {
         switch (BCSUTILS::Clamp(GetCVar("cl_zh2_identifyplayertype"), 0, 2))

--- a/pk3/ZombieHorde2/acs_source/zh2game/cvars.acs
+++ b/pk3/ZombieHorde2/acs_source/zh2game/cvars.acs
@@ -65,6 +65,18 @@ strict namespace ZH2Game
 
     internal bool GetClIdentifyPlayers() { return (bool)GetCvar("cl_zh2_identifyplayers"); }
     internal bool GetSvIdentifyPlayers() { return (bool)GetCvar("sv_zh2_identifyplayers"); }
+    internal IdentifyPlayerTypeT GetClIdentifyPlayerType()
+    {
+        switch (BCSUTILS::Clamp(GetCVar("cl_zh2_identifyplayertype"), 0, 2))
+        {
+            case 1:
+                return IDENTIFY_PLAYER_NAME;
+            case 2:
+                return IDENTIFY_PLAYER_SPECIE;
+            default:
+                return IDENTIFY_PLAYER_BOTH;
+        }
+    }
 
     internal bool GetAutoUseMedikits(int playerId) { return (bool)GetUserCvar(playerId, "cl_zh2_autousemedikits"); }
     internal bool GetAutoUseKevlars(int playerId) { return (bool)GetUserCvar(playerId, "cl_zh2_autousekevlars"); }

--- a/pk3/ZombieHorde2/acs_source/zh2game/hud/player/identity.acs
+++ b/pk3/ZombieHorde2/acs_source/zh2game/hud/player/identity.acs
@@ -39,20 +39,27 @@ strict namespace Hud
         int playerId = Identity::GetId(targetTid);
         int id = HUDID_IDENTITY;
 
-        Player::PlayerSpecieT specieSelf = Player::GetSpecie();
-
         BCSUtils::HudSetCenterText(true);
         BCSUtils::HudSetDisappearTime(0.5);
 
-        HudSetPointInternal();
-        BCSUtils::HudSetFont("SmallFont");
-        BCSUtils::HudDrawText(--id, BCSUtils::PlayerName(playerId));
-        DebugDraw();
+        ZH2Game::IdentifyPlayerTypeT identifyType = ZH2Game::GetClIdentifyPlayerType();
+        if (identifyType == ZH2Game::IDENTIFY_PLAYER_NAME || identifyType == ZH2Game::IDENTIFY_PLAYER_BOTH)
+        {
+            HudSetPointInternal();
+            BCSUtils::HudSetFont("SmallFont");
+            BCSUtils::HudDrawText(--id, BCSUtils::PlayerName(playerId));
+            DebugDraw();
+        }
 
         // Do not draw the specie until the round started.
         if (!Round::GetGameIsPlaying())
             return;
 
+        if (identifyType != ZH2Game::IDENTIFY_PLAYER_SPECIE && identifyType != ZH2Game::IDENTIFY_PLAYER_BOTH)
+            return;
+
+
+        Player::PlayerSpecieT specieSelf = Player::GetSpecie();
         Player::PlayerSpecieT specie = Player::GetPlayerSpecie(playerId);
         str specieLabel = Player::GetSpecieIndexAsString(specie);
 

--- a/pk3/ZombieHorde2/acs_source/zh2game/hud/player/identity.acs
+++ b/pk3/ZombieHorde2/acs_source/zh2game/hud/player/identity.acs
@@ -8,7 +8,8 @@ strict namespace Hud
 
     internal void DrawIdentity()
     {
-        if (!ZH2Game::GetSvIdentifyPlayers() || !ZH2Game::GetClIdentifyPlayers())
+        ZH2Game::IdentifyPlayerSpecieTypeT identifyPlayerType = ZH2Game::GetClIdentifyPlayers();
+        if (!ZH2Game::GetSvIdentifyPlayers() || identifyPlayerType == ZH2Game::IDENTIFY_PLAYER_OFF)
             return;
 
         BCSUtils::HudResetState();
@@ -23,10 +24,10 @@ strict namespace Hud
             BCSUtils::HudBottom() - 70.0,
             false);
 
-        DrawTargetIdentity();
+        DrawTargetIdentity(identifyPlayerType);
     }
 
-    internal void DrawTargetIdentity()
+    internal void DrawTargetIdentity(ZH2Game::IdentifyPlayerSpecieTypeT identifyPlayerType)
     {
         // Check for a player target, or stop.
         int targetTid = PickActor(0, GetActorAngle(0), GetActorPitch(0), HUD_IDENTITY_MAX_PICK_RANGE, 0, MF_SHOOTABLE, ML_BLOCKEVERYTHING | ML_BLOCKHITSCAN, PICKAF_RETURNTID);
@@ -37,6 +38,18 @@ strict namespace Hud
             return;
 
         int playerId = Identity::GetId(targetTid);
+
+        Player::PlayerSpecieT specieSelf = Player::GetSpecie();
+        Player::PlayerSpecieT specie = Player::GetPlayerSpecie(playerId);
+        bool match = specieSelf == specie;
+
+        if (identifyPlayerType != ZH2Game::IDENTIFY_PLAYER_ALL
+            && (identifyPlayerType == ZH2Game::IDENTIFY_PLAYER_ONLY_SAME && !match)
+            || (identifyPlayerType == ZH2Game::IDENTIFY_PLAYER_ONLY_OTHER && match))
+        {
+            return;
+        }
+
         int id = HUDID_IDENTITY;
 
         BCSUtils::HudSetCenterText(true);
@@ -58,9 +71,6 @@ strict namespace Hud
         if (identifyType != ZH2Game::IDENTIFY_PLAYER_SPECIE && identifyType != ZH2Game::IDENTIFY_PLAYER_BOTH)
             return;
 
-
-        Player::PlayerSpecieT specieSelf = Player::GetSpecie();
-        Player::PlayerSpecieT specie = Player::GetPlayerSpecie(playerId);
         str specieLabel = Player::GetSpecieIndexAsString(specie);
 
         BCSUtils::HudSetFont("SmallFont");

--- a/pk3/ZombieHorde2/acs_source/zh2game/hud/player/identity.acs
+++ b/pk3/ZombieHorde2/acs_source/zh2game/hud/player/identity.acs
@@ -8,7 +8,7 @@ strict namespace Hud
 
     internal void DrawIdentity()
     {
-        if (!ZH2Game::GetIdentifyPlayers())
+        if (!ZH2Game::GetSvIdentifyPlayers() || !ZH2Game::GetClIdentifyPlayers())
             return;
 
         BCSUtils::HudResetState();

--- a/pk3/ZombieHorde2/acs_source/zh2game/main.h.acs
+++ b/pk3/ZombieHorde2/acs_source/zh2game/main.h.acs
@@ -93,6 +93,13 @@ strict namespace ZH2Game
         DEATHTYPE_UNSAFE,
     };
 
+    internal enum IdentifyPlayerTypeT : int
+    {
+        IDENTIFY_PLAYER_BOTH,
+        IDENTIFY_PLAYER_NAME,
+        IDENTIFY_PLAYER_SPECIE,
+    };
+
     // General game info. Non-persisting between rounds.
     internal struct GameContextT
     {

--- a/pk3/ZombieHorde2/acs_source/zh2game/main.h.acs
+++ b/pk3/ZombieHorde2/acs_source/zh2game/main.h.acs
@@ -93,6 +93,14 @@ strict namespace ZH2Game
         DEATHTYPE_UNSAFE,
     };
 
+    internal enum IdentifyPlayerSpecieTypeT : int
+    {
+        IDENTIFY_PLAYER_OFF,
+        IDENTIFY_PLAYER_ALL,
+        IDENTIFY_PLAYER_ONLY_SAME,
+        IDENTIFY_PLAYER_ONLY_OTHER,
+    };
+
     internal enum IdentifyPlayerTypeT : int
     {
         IDENTIFY_PLAYER_BOTH,

--- a/pk3/ZombieHorde2/cvarinfo.txt
+++ b/pk3/ZombieHorde2/cvarinfo.txt
@@ -44,7 +44,7 @@ user int cl_zh2_showninventoryitems = 5;
 user bool cl_zh2_wrapinventoryitems = false;
 
 server bool sv_zh2_identifyplayers = true;
-user bool cl_zh2_identifyplayers = true;
+user int cl_zh2_identifyplayers = 1;
 user int cl_zh2_identifyplayertype = 0;
 
 user bool cl_zh2_autousemedikits = true;

--- a/pk3/ZombieHorde2/cvarinfo.txt
+++ b/pk3/ZombieHorde2/cvarinfo.txt
@@ -45,6 +45,7 @@ user bool cl_zh2_wrapinventoryitems = false;
 
 server bool sv_zh2_identifyplayers = true;
 user bool cl_zh2_identifyplayers = true;
+user int cl_zh2_identifyplayertype = 0;
 
 user bool cl_zh2_autousemedikits = true;
 user bool cl_zh2_autousekevlars = true;

--- a/pk3/ZombieHorde2/cvarinfo.txt
+++ b/pk3/ZombieHorde2/cvarinfo.txt
@@ -42,6 +42,8 @@ server bool sv_zh2_usecustomknockbackfeature = false;
 // Player
 user int cl_zh2_showninventoryitems = 5;
 user bool cl_zh2_wrapinventoryitems = false;
+
+server bool sv_zh2_identifyplayers = true;
 user bool cl_zh2_identifyplayers = true;
 
 user bool cl_zh2_autousemedikits = true;

--- a/pk3/ZombieHorde2/menudef.player
+++ b/pk3/ZombieHorde2/menudef.player
@@ -21,6 +21,13 @@ OptionValue "DamageFeedbackNumberShowType"
     2, "Show individual damage"
 }
 
+OptionValue "IdentifyPlayerType"
+{
+    0, "Show both"
+    1, "Show name"
+    2, "Show specie"
+}
+
 OptionMenu "ZH2PlayerMenu"
 {
     Title "Player"
@@ -43,6 +50,7 @@ OptionMenu "ZH2PlayerMenu"
     StaticText "Identify players", 1
     Option "Enable clientside", "cl_zh2_identifyplayers", "YesNo"
     Option "Enable serverside", "sv_zh2_identifyplayers", "YesNo"
+    Option "Identify type", "cl_zh2_identifyplayertype", "IdentifyPlayerType"
 
     StaticText " "
 	

--- a/pk3/ZombieHorde2/menudef.player
+++ b/pk3/ZombieHorde2/menudef.player
@@ -21,6 +21,14 @@ OptionValue "DamageFeedbackNumberShowType"
     2, "Show individual damage"
 }
 
+OptionValue "IdentifyPlayerSpecieType"
+{
+    0, "Off"
+    1, "All species"
+    2, "Only same species"
+    3, "Only other species"
+}
+
 OptionValue "IdentifyPlayerType"
 {
     0, "Show both"
@@ -48,8 +56,8 @@ OptionMenu "ZH2PlayerMenu"
     StaticText " "
 	
     StaticText "Identify players", 1
-    Option "Enable clientside", "cl_zh2_identifyplayers", "YesNo"
     Option "Enable serverside", "sv_zh2_identifyplayers", "YesNo"
+    Option "Enable clientside", "cl_zh2_identifyplayers", "IdentifyPlayerSpecieType"
     Option "Identify type", "cl_zh2_identifyplayertype", "IdentifyPlayerType"
 
     StaticText " "

--- a/pk3/ZombieHorde2/menudef.player
+++ b/pk3/ZombieHorde2/menudef.player
@@ -42,6 +42,7 @@ OptionMenu "ZH2PlayerMenu"
 	
     StaticText "Identify players", 1
     Option "Enable clientside", "cl_zh2_identifyplayers", "YesNo"
+    Option "Enable serverside", "sv_zh2_identifyplayers", "YesNo"
 
     StaticText " "
 	


### PR DESCRIPTION
Extensions to the identify players feature, putting it more in line with general new features added to ZH2. Implements #157.