### PR TITLE
#190 play timer delay

### DIFF
--- a/docs/patchnotes/zh2_beta_v6.0.0_patchnotes.txt
+++ b/docs/patchnotes/zh2_beta_v6.0.0_patchnotes.txt
@@ -78,3 +78,4 @@ Repository changes
 - Renamed the 'pk3/lib' folder to 'pk3/libraries/ZombieHorde2Lib' and updated the project to point to its new location.
 - Added a version.txt file which will contain the current version of the mod. One of the new Python scripts will use this file as reference when updating.
 - Builds made of the mod through PubDoomer in this project are now in lowercase rather than PascalCase.
+- Fixed an issue where the play timer was not set quick enough, causing early infections to not count towards the play timer.

--- a/pk3/ZombieHorde2/acs_source/zh2game/event/round.acs
+++ b/pk3/ZombieHorde2/acs_source/zh2game/event/round.acs
@@ -74,17 +74,26 @@ strict namespace Event
                 Game::SetGameStartTicNow();
                 Sync::SyncGame();
 
-                Delay(const: 35);
-
-                // Timer is completely optional in escape maps, so the map developer is free to leave it out.
+                // For the first second we hide the timer.
                 int index = RoundTimer::GetIndexOfKnownType(RoundTimer::TIMERPLAYING);
-                if (RoundTimer::GetTimerDefined(index))
+                bool defined = RoundTimer::GetTimerDefined(index);
+                if (defined)
                 {
                     RoundTimer::SetActiveTimerByKnownType(RoundTimer::TIMERPLAYING);
                     RoundTimer::StartTimer(index);
+                    RoundTimer::HideTimer(index);
                 }
 
                 Sync::SyncTimers();
+
+                Delay(const: 35);
+
+                if (defined)
+                {
+                    RoundTimer::ShowTimer(index);
+                    Sync::SyncTimers();
+                }
+
                 Delay(const: 35 * 2);
 
                 // Log a message to players to inform them of their specie and their task.


### PR DESCRIPTION
Fixed the issue where time wasn't added to the play timer when people infected others as soon as they got picked.